### PR TITLE
Fix all 7 MVP bugs, implement getters, remove stdlib dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
         run: make test
 
       - name: Memory check with Valgrind
-        run: valgrind --leak-check=full ./tests/ok_json_test_runner
+        run: valgrind --leak-check=full ./test/ok_json_test_runner

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -26,21 +26,67 @@
 
 #include "../include/ok_json.h"
 
-/* TODO: Remove dependency on these headers: */
-#include <ctype.h>
-#include <string.h>
+/* NULL is part of the C standard but lives in stddef.h which we avoid
+ * pulling in.  Define it here if the platform header hasn't provided it. */
+#ifndef NULL
+#define NULL ((void *)0)
+#endif
 
-/* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-#include <stdio.h>
+/* ---------------------------------------------------------------------------
+ * Internal helpers — no external library dependencies
+ * ---------------------------------------------------------------------------*/
+
+static int okj_is_whitespace(char c)
+{
+    return (c == ' ') || (c == '\t') || (c == '\n') || (c == '\r');
+}
+
+static int okj_is_digit(char c)
+{
+    return (c >= '0') && (c <= '9');
+}
+
+/* Returns 1 if the first `len` bytes of `src` equal `lit`, 0 otherwise.
+ * Stops early on a NUL byte in `src` to avoid overreads. */
+static int okj_match(const char *src, const char *lit, uint16_t len)
+{
+    uint16_t i;
+    for (i = 0U; i < len; i++)
+    {
+        if (src[i] == '\0' || src[i] != lit[i]) { return 0; }
+    }
+    return 1;
+}
+
+/* ---------------------------------------------------------------------------
+ * File-scope result structs returned by getter functions.
+ * Avoids dynamic allocation (suitable for embedded targets).
+ * ---------------------------------------------------------------------------*/
+
+static OkJsonString  s_string_result;
+static OkJsonNumber  s_number_result;
+static OkJsonBoolean s_boolean_result;
+static OkJsonArray   s_array_result;
+static OkJsonObject  s_object_result;
+
+/* ---------------------------------------------------------------------------
+ * Public API
+ * ---------------------------------------------------------------------------*/
 
 void okj_init(OkJsonParser *parser, char *json_string)
 {
     if (parser != NULL && json_string != NULL)
     {
-        parser->json = json_string;
-
-        parser->position    = 0;
-        parser->token_count = 0;
+        uint16_t i;
+        for (i = 0U; i < OKJ_MAX_TOKENS; i++)
+        {
+            parser->tokens[i].type   = OKJ_UNDEFINED;
+            parser->tokens[i].start  = NULL;
+            parser->tokens[i].length = 0U;
+        }
+        parser->json        = json_string;
+        parser->position    = 0U;
+        parser->token_count = 0U;
     }
 }
 
@@ -48,16 +94,20 @@ static void okj_skip_whitespace(OkJsonParser *parser)
 {
     if (parser != NULL)
     {
-        while (isspace(parser->json[parser->position]))
+        while (okj_is_whitespace(parser->json[parser->position]))
         {
             parser->position++;
         }
     }
 }
 
-static int okj_parse_value(OkJsonParser *parser)
+static OkjError okj_parse_value(OkJsonParser *parser)
 {
-    /* TODO: Refactor to use only one return. */
+    OkjError    result = OKJ_SUCCESS;
+    char        c;
+    OkJsonToken *tok;
+    uint16_t    start_pos;
+
     if (parser == NULL)
     {
         return OKJ_ERROR_BAD_POINTER;
@@ -65,235 +115,269 @@ static int okj_parse_value(OkJsonParser *parser)
 
     okj_skip_whitespace(parser);
 
-    char c = parser->json[parser->position];
-    
-    if (c == '{')
-    {
-        parser->tokens[parser->token_count].type = OKJ_OBJECT;
+    c = parser->json[parser->position];
 
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound object.\n");
+    if (c == '\0')
+    {
+        /* End of input — nothing to do. */
+    }
+    else if (c == '{')
+    {
+        tok         = &parser->tokens[parser->token_count];
+        tok->type   = OKJ_OBJECT;
+        tok->start  = &parser->json[parser->position];
+        tok->length = 1U;
+        parser->position++;
+        parser->token_count++;
     }
     else if (c == '[')
     {
-        parser->tokens[parser->token_count].type = OKJ_ARRAY;
-
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound array.\n");
+        tok         = &parser->tokens[parser->token_count];
+        tok->type   = OKJ_ARRAY;
+        tok->start  = &parser->json[parser->position];
+        tok->length = 1U;
+        parser->position++;
+        parser->token_count++;
+    }
+    else if (c == '}' || c == ']' || c == ',' || c == ':')
+    {
+        /* Structural punctuation — advance past it, emit no token. */
+        parser->position++;
     }
     else if (c == '"')
     {
-        parser->tokens[parser->token_count].type = OKJ_STRING;
+        tok        = &parser->tokens[parser->token_count];
+        tok->type  = OKJ_STRING;
+        tok->start = &parser->json[parser->position + 1U];  /* skip opening '"' */
+        start_pos  = parser->position + 1U;
+        parser->position++;
 
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound string.\n");
-
-        uint16_t start = parser->position;
-
-        while (
-               parser->json[++parser->position] != '\0' &&
-               //(isalnum(parser->json[++parser->position]))  ||
-               /* (ispunct(parser->json[parser->position]))    || TODO: Will come back to this. */
-               (parser->json[parser->position] != '"'))
+        while (parser->json[parser->position] != '"' &&
+               parser->json[parser->position] != '\0')
         {
-            /* Intentionally empty */
+            parser->position++;
         }
 
-        // /* A number cannot end with '.' */
-        // if (parser->json[parser->position - 1] == '.')
-        // {
-        //     /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        //     printf("\nBAD number!!!\n");
-
-        //     return OKJ_ERROR_BAD_NUMBER;
-        // }
-
-        parser->tokens[parser->token_count].length = parser->position - start;
-    }
-    else if ((isdigit(c)) || (c == '-'))
-    {
-        parser->tokens[parser->token_count].type = OKJ_NUMBER;
-
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound number.\n");
-
-        uint16_t start = parser->position;
-
-        while ((isdigit(parser->json[++parser->position]))  ||
-               (parser->json[parser->position] == '.'))
+        if (parser->json[parser->position] != '"')
         {
-            /* Intentionally empty */
+            result = OKJ_ERROR_SYNTAX;
+        }
+        else
+        {
+            tok->length = parser->position - start_pos;
+            parser->position++;   /* advance past closing '"' */
+            parser->token_count++;
+        }
+    }
+    else if (okj_is_digit(c) || c == '-')
+    {
+        tok        = &parser->tokens[parser->token_count];
+        tok->type  = OKJ_NUMBER;
+        tok->start = &parser->json[parser->position];
+        start_pos  = parser->position;
+        parser->position++;
+
+        while (okj_is_digit(parser->json[parser->position]) ||
+               parser->json[parser->position] == '.')
+        {
+            parser->position++;
         }
 
-        /* A number cannot end with '.' */
-        if (parser->json[parser->position - 1] == '.')
+        if (parser->json[parser->position - 1U] == '.')
         {
-            /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-            printf("\nBAD number!!!\n");
-
-            return OKJ_ERROR_BAD_NUMBER;
+            result = OKJ_ERROR_BAD_NUMBER;
         }
-
-        parser->tokens[parser->token_count].length = parser->position - start;
-
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nToken length == %d.\n", parser->tokens[parser->token_count].length);
+        else
+        {
+            tok->length = parser->position - start_pos;
+            parser->token_count++;
+        }
     }
-    else if ((strncmp(&parser->json[parser->position], "true",  4) == 0)   ||
-             (strncmp(&parser->json[parser->position], "false", 5) == 0))
+    else if (okj_match(&parser->json[parser->position], "true", 4U))
     {
-        parser->tokens[parser->token_count].type = OKJ_BOOLEAN;
-
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound boolean\n");
+        tok         = &parser->tokens[parser->token_count];
+        tok->type   = OKJ_BOOLEAN;
+        tok->start  = &parser->json[parser->position];
+        tok->length = 4U;
+        parser->position += 4U;
+        parser->token_count++;
     }
-    else if (strncmp(&parser->json[parser->position], "null", 4) == 0)
+    else if (okj_match(&parser->json[parser->position], "false", 5U))
     {
-        parser->tokens[parser->token_count].type = OKJ_NULL;
-
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nFound null.\n");
+        tok         = &parser->tokens[parser->token_count];
+        tok->type   = OKJ_BOOLEAN;
+        tok->start  = &parser->json[parser->position];
+        tok->length = 5U;
+        parser->position += 5U;
+        parser->token_count++;
+    }
+    else if (okj_match(&parser->json[parser->position], "null", 4U))
+    {
+        tok         = &parser->tokens[parser->token_count];
+        tok->type   = OKJ_NULL;
+        tok->start  = &parser->json[parser->position];
+        tok->length = 4U;
+        parser->position += 4U;
+        parser->token_count++;
     }
     else
     {
-        /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-        printf("\nJSON SYNTAX ERROR!\n");
-
-        /* Error: invalid JSON */
-        return OKJ_ERROR_SYNTAX;
+        result = OKJ_ERROR_SYNTAX;
     }
 
-    parser->tokens[parser->token_count].start = &parser->json[parser->position];
-
-    /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-    printf("\nToken start == %c\n", *parser->tokens[parser->token_count].start);
-
-    /* TODO: Placeholder, actual length needs to be determined. */
-    //parser->tokens[parser->token_count].length = 1;
-
-    /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-    printf("\nToken length == %d.\n", parser->tokens[parser->token_count].length);
-
-    parser->position++;
-
-    /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-    printf("\nParser position == %d.\n", parser->position);
-
-    parser->token_count++;
-
-    /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-    printf("\nToken count == %d.\n", parser->token_count);
-
-    return OKJ_SUCCESS;
+    return result;
 }
 
 OkjError okj_parse(OkJsonParser *parser)
 {
-    /* TODO: Refactor to use only one return. */
+    OkjError result = OKJ_SUCCESS;
+
     if (parser == NULL)
     {
         return OKJ_ERROR_BAD_POINTER;
     }
 
-    /* okj_init(parser, parser->json); */
-
-    /* TODO: What if the data legitmately contains the null char?  Is that possible? */
     while ((parser->json[parser->position] != '\0') &&
            (parser->token_count < OKJ_MAX_TOKENS))
     {
         if (okj_parse_value(parser) != OKJ_SUCCESS)
         {
-            /* RLM - FOR DEBUGGING!  REMOVE BEFORE COMMIT */
-            printf("\nPARSING ERROR!!!\n");
-
-            /* Parsing error */
-            return OKJ_ERROR_PARSING_FAILED;
+            result = OKJ_ERROR_PARSING_FAILED;
+            break;
         }
     }
-    
-    return OKJ_SUCCESS;
+
+    return result;
 }
+
+/* ---------------------------------------------------------------------------
+ * Internal lookup helper
+ * ---------------------------------------------------------------------------*/
+
+/* Scans the token array for a STRING token whose content equals `key`.
+ * Returns the index of the NEXT token (the value), or OKJ_MAX_TOKENS if
+ * not found. */
+static uint16_t okj_find_value_index(OkJsonParser *parser, const char *key)
+{
+    uint16_t i;
+    uint16_t key_len = 0U;
+
+    while (key[key_len] != '\0') { key_len++; }
+
+    for (i = 0U; (i + 1U) < parser->token_count; i++)
+    {
+        OkJsonToken *t = &parser->tokens[i];
+        if (t->type   == OKJ_STRING &&
+            t->length == key_len    &&
+            okj_match(t->start, key, key_len))
+        {
+            return i + 1U;
+        }
+    }
+
+    return OKJ_MAX_TOKENS;
+}
+
+/* ---------------------------------------------------------------------------
+ * Getter functions
+ * ---------------------------------------------------------------------------*/
 
 OkJsonString *okj_get_string(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS || parser->tokens[idx].type != OKJ_STRING)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-
-    return NULL;
+    s_string_result.start  = parser->tokens[idx].start;
+    s_string_result.length = parser->tokens[idx].length;
+    return &s_string_result;
 }
 
 OkJsonNumber *okj_get_number(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS || parser->tokens[idx].type != OKJ_NUMBER)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-    
-    return NULL;
+    s_number_result.start  = parser->tokens[idx].start;
+    s_number_result.length = parser->tokens[idx].length;
+    return &s_number_result;
 }
 
 OkJsonBoolean *okj_get_boolean(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS || parser->tokens[idx].type != OKJ_BOOLEAN)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-
-    return NULL;
+    s_boolean_result.start  = parser->tokens[idx].start;
+    s_boolean_result.length = parser->tokens[idx].length;
+    return &s_boolean_result;
 }
 
 OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS || parser->tokens[idx].type != OKJ_ARRAY)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-
-    return NULL;
+    s_array_result.start = parser->tokens[idx].start;
+    s_array_result.count = 0U;
+    return &s_array_result;
 }
 
 OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS || parser->tokens[idx].type != OKJ_OBJECT)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-
-    return NULL;
+    s_object_result.start = parser->tokens[idx].start;
+    s_object_result.count = 0U;
+    return &s_object_result;
 }
 
 OkJsonToken *okj_get_token(OkJsonParser *parser, const char *key)
 {
-    /* TODO: stub */
-    if (parser == NULL || key == NULL)
+    uint16_t idx;
+
+    if (parser == NULL || key == NULL) { return NULL; }
+
+    idx = okj_find_value_index(parser, key);
+    if (idx == OKJ_MAX_TOKENS)
     {
         return NULL;
     }
 
-    (void)parser;
-    (void)key;
-    
-    return NULL;
+    return &parser->tokens[idx];
 }

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -46,21 +46,22 @@ void test_parse_simple_object(void)
 {
     /* Parse a basic JSON object and test for two things:
      *   - Ensure parsing succeeds
-     *   - Parse the correct number of objects (two, in this case)
+     *   - Parse the correct number of tokens (three: container, key, value)
      */
-        
+
     OkJsonParser parser;
     char json_str[] = "{\"key\": 42}";
-    
+
     okj_init(&parser, json_str);
 
     OkjError result = okj_parse(&parser);
 
-    assert(result == OKJ_SUCCESS); 
-    assert(parser.token_count == 2);
+    assert(result == OKJ_SUCCESS);
+    assert(parser.token_count == 3);
 
     assert(parser.tokens[0].type == OKJ_OBJECT);
-    assert(parser.tokens[1].type == OKJ_NUMBER);
+    assert(parser.tokens[1].type == OKJ_STRING);   /* "key"  */
+    assert(parser.tokens[2].type == OKJ_NUMBER);   /* 42     */
 
     printf("✅ test_parse_simple_object passed!\n");
 }


### PR DESCRIPTION
Rewrites okj_parse_value() to fix token.start/length assignments (BUGs 1–6):
- token.start now captured before scanning, not after (BUG-3, BUG-6)
- STRING length is content-only, excluding surrounding quotes (BUG-4)
- BOOLEAN/NULL advance position by keyword length (BUG-2)
- Structural chars (,  : } ]) are consumed without emitting a token (BUG-1)
- okj_init() zero-initialises the tokens array (BUG-5)

BUG-7 (key-token model, Option A): keys ARE emitted as STRING tokens. test_parse_simple_object updated to expect 3 tokens [OBJECT, STRING, NUMBER].

Implements all 6 stub getter functions via okj_find_value_index() lookup.

Replaces isspace/isdigit/strncmp with inline helpers; removes #include directives for ctype.h, string.h, and stdio.h (all debug printfs removed). NULL defined locally to avoid stddef.h.

Fixes CI Valgrind path: ./tests/ -> ./test/

All 3 tests pass; Valgrind reports 0 errors, 0 leaks.

https://claude.ai/code/session_015YGmP2NWeGS19GHLT5rWP1