### PR TITLE
Fix #3 and #4: populate array/object count and enforce string length …

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -59,6 +59,157 @@ static int okj_match(const char *src, const char *lit, uint16_t len)
 }
 
 /* ---------------------------------------------------------------------------
+ * Helpers for counting array elements and object members in the raw JSON
+ * string.  These walk the source text so the counts are accurate even when
+ * multiple values appear at the same nesting level.
+ * ---------------------------------------------------------------------------*/
+
+/* Advance `p` past a JSON string (including both surrounding quotes).
+ * `p` must point at the opening '"'.  Returns a pointer to the character
+ * immediately following the closing '"', or to '\0' on unterminated input. */
+static const char *okj_skip_string(const char *p)
+{
+    p++;    /* skip opening '"' */
+
+    while ((*p != '"') && (*p != '\0'))
+    {
+        p++;
+    }
+
+    if (*p == '"')
+    {
+        p++;    /* skip closing '"' */
+    }
+
+    return p;
+}
+
+/* Count the number of elements in a JSON array whose text begins at `start`
+ * (which must point to the '[' character).  Handles nested arrays and objects
+ * correctly by tracking bracket depth, and skips string content to avoid
+ * counting structural characters that appear inside quoted values. */
+static uint16_t okj_count_array_elements(const char *start)
+{
+    uint16_t    depth = 0U;
+    uint16_t    count = 0U;
+    uint8_t     seen  = 0U;    /* set when first non-whitespace element is found */
+    const char *p     = start;
+
+    if ((p == NULL) || (*p != '['))
+    {
+        return 0U;
+    }
+
+    p++;        /* skip '[' */
+    depth = 1U;
+
+    while ((*p != '\0') && (depth > 0U))
+    {
+        char c = *p;
+
+        if (c == '"')
+        {
+            /* Skip string content so commas inside strings are not counted. */
+            p = okj_skip_string(p);
+
+            if ((depth == 1U) && (seen == 0U))
+            {
+                seen = 1U;
+            }
+        }
+        else
+        {
+            if ((c == '[') || (c == '{'))
+            {
+                if ((depth == 1U) && (seen == 0U))
+                {
+                    seen = 1U;
+                }
+                depth++;
+            }
+            else if ((c == ']') || (c == '}'))
+            {
+                depth--;
+            }
+            else if ((c == ',') && (depth == 1U))
+            {
+                count++;
+            }
+            else if ((!okj_is_whitespace(c)) && (depth == 1U) && (seen == 0U))
+            {
+                seen = 1U;
+            }
+            else
+            {
+                /* Other characters (digits, letters, etc.) need no action. */
+            }
+
+            p++;
+        }
+    }
+
+    /* The comma count equals elements-minus-one for a non-empty array. */
+    if (seen != 0U)
+    {
+        count++;
+    }
+
+    return count;
+}
+
+/* Count the number of key-value members in a JSON object whose text begins
+ * at `start` (which must point to the '{' character).  Each colon at depth 1
+ * corresponds to exactly one member. */
+static uint16_t okj_count_object_members(const char *start)
+{
+    uint16_t    depth = 0U;
+    uint16_t    count = 0U;
+    const char *p     = start;
+
+    if ((p == NULL) || (*p != '{'))
+    {
+        return 0U;
+    }
+
+    p++;        /* skip '{' */
+    depth = 1U;
+
+    while ((*p != '\0') && (depth > 0U))
+    {
+        char c = *p;
+
+        if (c == '"')
+        {
+            /* Skip string content so colons inside keys/values are ignored. */
+            p = okj_skip_string(p);
+        }
+        else
+        {
+            if ((c == '[') || (c == '{'))
+            {
+                depth++;
+            }
+            else if ((c == ']') || (c == '}'))
+            {
+                depth--;
+            }
+            else if ((c == ':') && (depth == 1U))
+            {
+                count++;
+            }
+            else
+            {
+                /* Other characters need no action. */
+            }
+
+            p++;
+        }
+    }
+
+    return count;
+}
+
+/* ---------------------------------------------------------------------------
  * File-scope result structs returned by getter functions.
  * Avoids dynamic allocation (suitable for embedded targets).
  * ---------------------------------------------------------------------------*/
@@ -160,10 +311,21 @@ static OkjError okj_parse_value(OkJsonParser *parser)
         while ((parser->json[parser->position] != '"') &&
                (parser->json[parser->position] != '\0'))
         {
+            if ((parser->position - start_pos) >= OKJ_MAX_STRING_LEN)
+            {
+                break;
+            }
+
             parser->position++;
         }
 
-        if (parser->json[parser->position] != '"')
+        if ((parser->json[parser->position] != '"') &&
+            (parser->json[parser->position] != '\0'))
+        {
+            /* Loop exited due to the length limit, not a closing quote. */
+            result = OKJ_ERROR_MAX_STR_LEN_EXCEEDED;
+        }
+        else if (parser->json[parser->position] != '"')
         {
             result = OKJ_ERROR_SYNTAX;
         }
@@ -258,10 +420,10 @@ OkjError okj_parse(OkJsonParser *parser)
     while ((parser->json[parser->position] != '\0') &&
            (parser->token_count < OKJ_MAX_TOKENS))
     {
-        if (okj_parse_value(parser) != OKJ_SUCCESS)
-        {
-            result = OKJ_ERROR_PARSING_FAILED;
+        result = okj_parse_value(parser);
 
+        if (result != OKJ_SUCCESS)
+        {
             break;
         }
     }
@@ -395,7 +557,7 @@ OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)
     }
 
     s_array_result.start = parser->tokens[idx].start;
-    s_array_result.count = 0U;
+    s_array_result.count = okj_count_array_elements(parser->tokens[idx].start);
 
     return &s_array_result;
 }
@@ -417,7 +579,7 @@ OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)
     }
 
     s_object_result.start = parser->tokens[idx].start;
-    s_object_result.count = 0U;
+    s_object_result.count = okj_count_object_members(parser->tokens[idx].start);
 
     return &s_object_result;
 }

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -42,6 +42,9 @@ void test_invalid_boolean(void);
 void test_get_not_found(void);
 void test_max_tokens_exceeded(void);
 void test_truncated_string(void);
+void test_get_array_count(void);
+void test_get_object_count(void);
+void test_string_too_long(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -326,6 +329,93 @@ void test_truncated_string(void)
     printf("test_truncated_string passed!\n");
 }
 
+void test_get_array_count(void)
+{
+    /* Parse an object that contains an array value and verify that
+     * okj_get_array() returns the correct element count. */
+
+    OkJsonParser parser;
+    OkJsonArray *arr;
+    char json_str[] = "{\"items\": [1, 2, 3]}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    arr = okj_get_array(&parser, "items");
+
+    assert(arr != NULL);
+    assert(arr->count == 3U);   /* three numeric elements */
+
+    printf("test_get_array_count passed!\n");
+}
+
+void test_get_object_count(void)
+{
+    /* Parse an object that contains a nested object value and verify that
+     * okj_get_object() returns the correct member count. */
+
+    OkJsonParser  parser;
+    OkJsonObject *obj;
+    char json_str[] = "{\"info\": {\"a\": 1, \"b\": 2}}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    obj = okj_get_object(&parser, "info");
+
+    assert(obj != NULL);
+    assert(obj->count == 2U);   /* two key-value members */
+
+    printf("test_get_object_count passed!\n");
+}
+
+void test_string_too_long(void)
+{
+    /* Attempt to parse an object whose string value exceeds OKJ_MAX_STRING_LEN
+     * (64 bytes).  The parser should return OKJ_ERROR_MAX_STR_LEN_EXCEEDED.
+     *
+     * Buffer layout: {"k":"<65 x chars>"}
+     *   '{'  = 1
+     *   '"k"' = 3
+     *   ':'  = 1
+     *   '"'  = 1  (opening quote of value)
+     *   65 x = 65
+     *   '"'  = 1  (closing quote)
+     *   '}'  = 1
+     *   '\0' = 1
+     *   Total = 74 bytes
+     */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char         json_str[74];
+    uint16_t     i;
+    uint16_t     pos = 0U;
+
+    json_str[pos++] = '{';
+    json_str[pos++] = '"';
+    json_str[pos++] = 'k';
+    json_str[pos++] = '"';
+    json_str[pos++] = ':';
+    json_str[pos++] = '"';
+
+    for (i = 0U; i < 65U; i++)
+    {
+        json_str[pos++] = 'x';
+    }
+
+    json_str[pos++] = '"';
+    json_str[pos++] = '}';
+    json_str[pos]   = '\0';
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_MAX_STR_LEN_EXCEEDED);
+
+    printf("test_string_too_long passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -344,6 +434,9 @@ int main(int argc, char* argv[])
     test_get_not_found();
     test_max_tokens_exceeded();
     test_truncated_string();
+    test_get_array_count();
+    test_get_object_count();
+    test_string_too_long();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
…limit

#3 - okj_get_array() and okj_get_object() now return an accurate count field by walking the raw JSON text rather than returning 0U unconditionally. Added three static helpers in ok_json.c:
  - okj_skip_string(): advances past a quoted JSON string
  - okj_count_array_elements(): counts comma-delimited elements at depth 1, skipping nested arrays/objects and string content
  - okj_count_object_members(): counts colons at depth 1 (one per member), skipping nested structures and string content

#4 - The string scan loop in okj_parse_value() now breaks when the running length reaches OKJ_MAX_STRING_LEN and returns OKJ_ERROR_MAX_STR_LEN_EXCEEDED instead of scanning unbounded input.

Also changed okj_parse() to propagate the specific error code from okj_parse_value() rather than always returning OKJ_ERROR_PARSING_FAILED, which lets callers distinguish error causes without digging into internals.

Three new tests added (16 total, all passing):
  - test_get_array_count: verifies count == 3 for a three-element array
  - test_get_object_count: verifies count == 2 for a two-member nested object
  - test_string_too_long: verifies OKJ_ERROR_MAX_STR_LEN_EXCEEDED for a 65-character value string (one over the 64-byte limit)

https://claude.ai/code/session_01TFz4uUuUb77evcWUexuxGv