### PR TITLE
Fix #7: handle backslash escape sequences in string scanning

### DIFF
--- a/TODO_LIST
+++ b/TODO_LIST
@@ -1,6 +1,6 @@
 Items that I want/need to work on:
 
-MVP is complete as of 2026-03-05. All 13 tests pass. Zero stdlib dependencies.
+MVP is complete as of 2026-03-05. All 18 tests pass. Zero stdlib dependencies.
 See MVP_ROADMAP.md for the full historical task list with completion status.
 
 Post-MVP items remaining:
@@ -12,42 +12,23 @@ Post-MVP items remaining:
   formal analysis; continue deferring the toolchain requirement, but the code
   change itself is small.
 
-* Remove or repurpose test/ok_json_test_runner.c.
+* Remove or repurpose test/ok_json_test_runner.c. (deferred by user)
   The file currently contains only "/* placeholder */" and is not compiled by
   the Makefile (the test binary is built from ok_json_tests.c which already
   has main()).  Either delete it or use it as a separate harness entry point
   if the test suite is ever split into declaration and runner files.
 
-* Remove OKJ_VALID_CHARS from ok_json.h or put it to use.
+* Remove OKJ_VALID_CHARS from ok_json.h or put it to use. (deferred by user)
   The 96-element static const array is defined in the header but referenced
   nowhere in ok_json.c or the tests.  As a static in a header it gets
   duplicated into every translation unit that includes the header, wasting
-  ROM.  Either use it in the string scanner to validate characters, or remove
-  it entirely.
-
-* Populate the count field in okj_get_array() and okj_get_object().
-  Both functions currently return count = 0U unconditionally.  A useful
-  implementation would scan the token array from the matching ARRAY/OBJECT
-  token forward and count the direct children (one depth level only for the
-  flat-token model).
-
-* Enforce OKJ_MAX_STRING_LEN during string parsing.
-  The string scanner in okj_parse_value() does not check whether the string
-  length exceeds OKJ_MAX_STRING_LEN.  Add a check in the scan loop and return
-  OKJ_ERROR_MAX_STR_LEN_EXCEEDED if the limit is hit.
+  ROM.  Intended to be used for string character validation in the future.
 
 * Add test for deeply nested JSON input.
   The test suite has no case that exercises behaviour at the nesting boundary
   (e.g., objects nested inside objects).  Define whether the parser should
   return an error or silently parse what it can, then add a test that asserts
   the chosen behaviour.
-
-* Add string escape sequence handling.
-  The string scanner does not interpret \", \\, \n, \t, or \uXXXX.  A
-  backslash in the input currently causes the scanner to stop at the next
-  unescaped quote, producing wrong token lengths.  At minimum, skip over \\
-  and \" pairs in the scan loop so that escaped quotes do not terminate the
-  string prematurely.
 
 * Add exponent notation support for numbers.
   The number scanner handles digits and '.', but does not handle 'e' or 'E'
@@ -59,6 +40,26 @@ Post-MVP items remaining:
     - Nested object inside object (tests nesting behaviour)
     - Nested array inside object (tests mixed nesting)
     - Number with exponent (tests rejection or acceptance once implemented)
-    - String with escape sequence (tests \\" and \\\\ handling)
     - Empty object {} and empty array []
     - Key with length at and above OKJ_MAX_STRING_LEN boundary
+
+Completed post-MVP items:
+
+* [DONE] Populate the count field in okj_get_array() and okj_get_object().
+  Both functions now walk the raw JSON text to count array elements (by
+  commas at depth 1) and object members (by colons at depth 1), with proper
+  string skipping so structural characters inside quoted values are ignored.
+
+* [DONE] Enforce OKJ_MAX_STRING_LEN during string parsing.
+  The string scanner now breaks out of its scan loop when the running raw
+  byte length reaches OKJ_MAX_STRING_LEN and returns
+  OKJ_ERROR_MAX_STR_LEN_EXCEEDED.
+
+* [DONE] Add string escape sequence handling.
+  Both the main string scan loop in okj_parse_value() and the okj_skip_string()
+  helper used by the count functions now recognise backslash escapes.  When a
+  '\' is encountered, the scanner advances past it and the following character
+  unconditionally, so that \" does not prematurely terminate a string and \\
+  is counted as one escape unit rather than two separate characters.  Token
+  start and length report raw bytes (escape sequences included), consistent
+  with the rest of the API.

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -66,13 +66,25 @@ static int okj_match(const char *src, const char *lit, uint16_t len)
 
 /* Advance `p` past a JSON string (including both surrounding quotes).
  * `p` must point at the opening '"'.  Returns a pointer to the character
- * immediately following the closing '"', or to '\0' on unterminated input. */
+ * immediately following the closing '"', or to '\0' on unterminated input.
+ * Recognises backslash escapes so that \" inside a string does not
+ * prematurely terminate the scan. */
 static const char *okj_skip_string(const char *p)
 {
     p++;    /* skip opening '"' */
 
     while ((*p != '"') && (*p != '\0'))
     {
+        if (*p == '\\')
+        {
+            p++;    /* skip the backslash */
+
+            if (*p == '\0')
+            {
+                break;  /* truncated input: backslash at end of stream */
+            }
+        }
+
         p++;
     }
 
@@ -314,6 +326,16 @@ static OkjError okj_parse_value(OkJsonParser *parser)
             if ((parser->position - start_pos) >= OKJ_MAX_STRING_LEN)
             {
                 break;
+            }
+
+            if (parser->json[parser->position] == '\\')
+            {
+                parser->position++;     /* skip backslash */
+
+                if (parser->json[parser->position] == '\0')
+                {
+                    break;  /* truncated input: backslash at end of stream */
+                }
             }
 
             parser->position++;

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -45,6 +45,8 @@ void test_truncated_string(void);
 void test_get_array_count(void);
 void test_get_object_count(void);
 void test_string_too_long(void);
+void test_escaped_quote_in_string(void);
+void test_escaped_backslash_in_string(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -416,6 +418,54 @@ void test_string_too_long(void)
     printf("test_string_too_long passed!\n");
 }
 
+void test_escaped_quote_in_string(void)
+{
+    /* Parse a string value that contains an escaped double-quote (\").
+     * The scanner must not treat \" as the closing quote; the token
+     * length must cover all raw bytes including the backslash. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+
+    /* JSON: {"msg": "say \"hi\""} — value raw bytes: say \"hi\" (10 bytes) */
+    char json_str[] = "{\"msg\": \"say \\\"hi\\\"\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "msg");
+
+    assert(str != NULL);
+    assert(str->length == 10U);     /* s,a,y, ,\,",h,i,\," */
+    assert(str->start[0] == 's');
+
+    printf("test_escaped_quote_in_string passed!\n");
+}
+
+void test_escaped_backslash_in_string(void)
+{
+    /* Parse a string value that contains an escaped backslash (\\).
+     * The scanner must treat \\ as a single escape unit and continue,
+     * not stop at the second backslash mistaking it for an escape prefix. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+
+    /* JSON: {"path": "a\\b"} — value raw bytes: a,\,\,b (4 bytes) */
+    char json_str[] = "{\"path\": \"a\\\\b\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "path");
+
+    assert(str != NULL);
+    assert(str->length == 4U);      /* a, \, \, b */
+    assert(str->start[0] == 'a');
+
+    printf("test_escaped_backslash_in_string passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -437,6 +487,8 @@ int main(int argc, char* argv[])
     test_get_array_count();
     test_get_object_count();
     test_string_too_long();
+    test_escaped_quote_in_string();
+    test_escaped_backslash_in_string();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
Both the main parse loop and the okj_skip_string() helper (used by the array/object count functions) now recognise backslash escapes.  When a '\' is seen, the scanner advances past it and the immediately following character unconditionally.  This ensures that:

  - \" does not prematurely terminate a string token
  - \\ is consumed as one escape unit, not mistaken for two characters
  - All other single-char escapes (\n, \t, \r, \b, \f, \/) and the six-char \uXXXX sequences are handled correctly by the same rule (the character after '\' is always skipped, and for \uXXXX the four hex digits are then scanned as ordinary content)

Truncated input ending with a bare '\' is detected: the inner advance hits '\0', breaks out of the loop, and the existing '\0' check returns OKJ_ERROR_SYNTAX as before.

Token start and length continue to report raw bytes including escape sequences; callers that need the decoded value must interpret them.

Two new tests added (18 total, all passing):
  - test_escaped_quote_in_string: "say \"hi\"" — length 10, starts 's'
  - test_escaped_backslash_in_string: "a\\b" — length 4, starts 'a'

TODO_LIST updated to mark #7 done and reflect the current test count.

https://claude.ai/code/session_01TFz4uUuUb77evcWUexuxGv