### PR TITLE
Add MISRA-oriented warning flags to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -Werror -std=c99 -pedantic -Iinclude
+CFLAGS = -Wall -Wextra -Werror -std=c99 -pedantic -Iinclude \
+         -Wconversion -Wsign-conversion -Wfloat-equal -Wcast-qual \
+         -Wcast-align -Wpointer-arith -Wshadow -Wlogical-op -Wundef \
+         -Wswitch-default -Wswitch-enum -Wunreachable-code -O0
 
 SRC = src/ok_json.c
 TEST_SRC = test/ok_json_tests.c


### PR DESCRIPTION
Adds the following flags for stricter compile-time checking in line with MISRA C2012 static-analysis intent:

  -Wconversion -Wsign-conversion  (implicit narrowing / sign changes)
  -Wfloat-equal                   (exact float comparison)
  -Wcast-qual -Wcast-align        (qualifier stripping / alignment casts)
  -Wpointer-arith                 (pointer arithmetic on void/function ptrs)
  -Wshadow                        (variable shadowing)
  -Wlogical-op                    (suspicious logical operators)
  -Wundef                         (use of undefined macros in #if)
  -Wswitch-default -Wswitch-enum  (missing default / unhandled enum values)
  -Wunreachable-code              (dead code)
  -O0                             (no optimisation; preserves debug clarity)

All 18 tests continue to pass with zero warnings under the expanded flags. No code changes were required.

https://claude.ai/code/session_01TFz4uUuUb77evcWUexuxGv