### PR TITLE
Enforce max array and object size limits in getters

### DIFF
--- a/include/ok_json.h
+++ b/include/ok_json.h
@@ -66,9 +66,11 @@ static const uint16_t OKJ_MAX_STRING_LEN = 64U;
 static const uint16_t OKJ_MAX_ARRAY_SIZE = 64U;
 
 /**
- * @brief Maximum size of array to process
+ * @brief Maximum number of key-value members in an object to process.
+ * Note: must stay below (OKJ_MAX_TOKENS - 1) / 2 so that a fully-parsed
+ * object never exhausts the token budget before the member limit fires.
  **/
-static const uint16_t OKJ_MAX_OBJECT_SIZE = 64U;
+static const uint16_t OKJ_MAX_OBJECT_SIZE = 32U;
 
 /**
  * @brief Array of all valid ASCII characters for string processing

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -581,6 +581,11 @@ OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)
     s_array_result.start = parser->tokens[idx].start;
     s_array_result.count = okj_count_array_elements(parser->tokens[idx].start);
 
+    if (s_array_result.count > OKJ_MAX_ARRAY_SIZE)
+    {
+        return NULL;
+    }
+
     return &s_array_result;
 }
 
@@ -602,6 +607,11 @@ OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)
 
     s_object_result.start = parser->tokens[idx].start;
     s_object_result.count = okj_count_object_members(parser->tokens[idx].start);
+
+    if (s_object_result.count > OKJ_MAX_OBJECT_SIZE)
+    {
+        return NULL;
+    }
 
     return &s_object_result;
 }

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -47,6 +47,8 @@ void test_get_object_count(void);
 void test_string_too_long(void);
 void test_escaped_quote_in_string(void);
 void test_escaped_backslash_in_string(void);
+void test_array_too_large(void);
+void test_object_too_large(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -466,6 +468,123 @@ void test_escaped_backslash_in_string(void)
     printf("test_escaped_backslash_in_string passed!\n");
 }
 
+void test_array_too_large(void)
+{
+    /* Build {"items": [1,1,...,1]} with 65 elements — one more than
+     * OKJ_MAX_ARRAY_SIZE (64).  Parsing must succeed (only 68 tokens are
+     * needed), but okj_get_array() must return NULL because the element
+     * count exceeds the configured limit. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    OkJsonArray *arr;
+
+    /* Buffer: {"items": [  65 ones with 64 commas  ]}  + NUL
+     *   10 + (65 + 64) + 2 + 1 = 142 bytes             */
+    char     json_str[142];
+    uint16_t pos = 0U;
+    uint16_t i;
+
+    json_str[pos++] = '{';
+    json_str[pos++] = '"';
+    json_str[pos++] = 'i';
+    json_str[pos++] = 't';
+    json_str[pos++] = 'e';
+    json_str[pos++] = 'm';
+    json_str[pos++] = 's';
+    json_str[pos++] = '"';
+    json_str[pos++] = ':';
+    json_str[pos++] = '[';
+
+    for (i = 0U; i < 65U; i++)
+    {
+        if (i > 0U) { json_str[pos++] = ','; }
+        json_str[pos++] = '1';
+    }
+
+    json_str[pos++] = ']';
+    json_str[pos++] = '}';
+    json_str[pos]   = '\0';
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_SUCCESS);     /* 68 tokens — well within limit */
+
+    arr = okj_get_array(&parser, "items");
+
+    assert(arr == NULL);               /* 65 > OKJ_MAX_ARRAY_SIZE(64)   */
+
+    printf("test_array_too_large passed!\n");
+}
+
+void test_object_too_large(void)
+{
+    /* Build {"data": {"k0":1,"k1":1,...,"k32":1}} — 33 members in the
+     * nested object, one more than OKJ_MAX_OBJECT_SIZE (32).  Parsing
+     * succeeds (69 tokens needed, within OKJ_MAX_TOKENS=128), but
+     * okj_get_object() must return NULL because the member count exceeds
+     * the configured limit. */
+
+    OkJsonParser  parser;
+    OkjError      result;
+    OkJsonObject *obj;
+
+    /* Worst-case size: 9 + 253 + 2 + 1 = 265 bytes (see comment below) */
+    char     json_str[265];
+    uint16_t pos = 0U;
+    uint16_t i;
+
+    /* Outer wrapper: {"data": { */
+    json_str[pos++] = '{';
+    json_str[pos++] = '"';
+    json_str[pos++] = 'd';
+    json_str[pos++] = 'a';
+    json_str[pos++] = 't';
+    json_str[pos++] = 'a';
+    json_str[pos++] = '"';
+    json_str[pos++] = ':';
+    json_str[pos++] = '{';
+
+    /* 33 members: "k0":1 … "k32":1 */
+    for (i = 0U; i < 33U; i++)
+    {
+        if (i > 0U) { json_str[pos++] = ','; }
+
+        json_str[pos++] = '"';
+        json_str[pos++] = 'k';
+
+        if (i < 10U)
+        {
+            json_str[pos++] = (char)('0' + (char)i);
+        }
+        else
+        {
+            json_str[pos++] = (char)('0' + (char)(i / 10U));
+            json_str[pos++] = (char)('0' + (char)(i % 10U));
+        }
+
+        json_str[pos++] = '"';
+        json_str[pos++] = ':';
+        json_str[pos++] = '1';
+    }
+
+    json_str[pos++] = '}';
+    json_str[pos++] = '}';
+    json_str[pos]   = '\0';
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_SUCCESS);     /* 69 tokens — well within limit */
+
+    obj = okj_get_object(&parser, "data");
+
+    assert(obj == NULL);               /* 33 > OKJ_MAX_OBJECT_SIZE(32)  */
+
+    printf("test_object_too_large passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -489,6 +608,8 @@ int main(int argc, char* argv[])
     test_string_too_long();
     test_escaped_quote_in_string();
     test_escaped_backslash_in_string();
+    test_array_too_large();
+    test_object_too_large();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
- okj_get_array(): return NULL when element count exceeds OKJ_MAX_ARRAY_SIZE
- okj_get_object(): return NULL when member count exceeds OKJ_MAX_OBJECT_SIZE
- Lower OKJ_MAX_OBJECT_SIZE from 64 to 32: with OKJ_MAX_TOKENS=128, a 64-member object requires 129 tokens (1+64+64), making the old limit unreachable before the token budget fires; 32 is both enforceable and consistent with the token cap
- Fix copy-paste error in OKJ_MAX_OBJECT_SIZE doc comment (said "array")
- Add test_array_too_large: 65-element array returns NULL from okj_get_array()
- Add test_object_too_large: 33-member nested object returns NULL from okj_get_object()
- All 20 tests pass under -Wall -Wextra -Werror -pedantic

https://claude.ai/code/session_0182Yz4ddv5Nn9xCTPn26Ez5