### PR TITLE
Add array/object raw getters, element counters, and debug print

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ CC = gcc
 CFLAGS = -Wall -Wextra -Werror -std=c99 -pedantic -Iinclude \
          -Wconversion -Wsign-conversion -Wfloat-equal -Wcast-qual \
          -Wcast-align -Wpointer-arith -Wshadow -Wlogical-op -Wundef \
-         -Wswitch-default -Wswitch-enum -Wunreachable-code -O0
+         -Wswitch-default -Wswitch-enum -Wunreachable-code -O0 \
+         -DOK_JSON_DEBUG
 
 SRC = src/ok_json.c
 TEST_SRC = test/ok_json_tests.c

--- a/include/ok_json.h
+++ b/include/ok_json.h
@@ -141,6 +141,7 @@ typedef struct
 {
     char *start;           /* Pointer to start of token in JSON string */
     uint16_t count;        /* Total count of object members            */
+    uint16_t length;       /* Full raw text length including braces    */
 } OkJsonObject;
 
 /**
@@ -150,6 +151,7 @@ typedef struct
 {
     char *start;           /* Pointer to start of token in JSON string */
     uint16_t count;        /* Total count of array elements            */
+    uint16_t length;       /* Full raw text length including brackets  */
 } OkJsonArray;
 
 /**
@@ -273,5 +275,66 @@ OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key);
  *         not found
  **/
 OkJsonToken *okj_get_token(OkJsonParser *parser, const char *key);
+
+/**
+ * @brief Retrieve the entire raw array value associated with a key.
+ *        Like okj_get_array() but also populates the @c length field with the
+ *        full byte count of the array text (including surrounding brackets) and
+ *        does NOT enforce OKJ_MAX_ARRAY_SIZE.  Use this when you need the
+ *        complete raw text of an array regardless of its element count.
+ * @param parser Pointer to the main ok_json parser object
+ * @param key    Null-terminated key name to look up
+ * @return Pointer to a static OkJsonArray with start, count, and length
+ *         populated, or NULL if not found or type mismatch
+ **/
+OkJsonArray *okj_get_array_raw(OkJsonParser *parser, const char *key);
+
+/**
+ * @brief Retrieve the entire raw object value associated with a key.
+ *        Like okj_get_object() but also populates the @c length field with the
+ *        full byte count of the object text (including surrounding braces) and
+ *        does NOT enforce OKJ_MAX_OBJECT_SIZE.  Use this when you need the
+ *        complete raw text of an object regardless of its member count.
+ * @param parser Pointer to the main ok_json parser object
+ * @param key    Null-terminated key name to look up
+ * @return Pointer to a static OkJsonObject with start, count, and length
+ *         populated, or NULL if not found or type mismatch
+ **/
+OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key);
+
+/**
+ * @brief Return the total number of OKJ_OBJECT tokens in the parsed result.
+ *        Counts every object opening brace that was tokenised, including
+ *        nested objects.
+ * @param parser Pointer to the main ok_json parser object
+ * @return Count of OKJ_OBJECT tokens, or 0 if @p parser is NULL
+ **/
+uint16_t okj_count_objects(OkJsonParser *parser);
+
+/**
+ * @brief Return the total number of OKJ_ARRAY tokens in the parsed result.
+ *        Counts every array opening bracket that was tokenised, including
+ *        nested arrays.
+ * @param parser Pointer to the main ok_json parser object
+ * @return Count of OKJ_ARRAY tokens, or 0 if @p parser is NULL
+ **/
+uint16_t okj_count_arrays(OkJsonParser *parser);
+
+/**
+ * @brief Return the total number of tokens (elements of any type) produced
+ *        by a successful parse.  Equivalent to @c parser->token_count.
+ * @param parser Pointer to the main ok_json parser object
+ * @return Total token count, or 0 if @p parser is NULL
+ **/
+uint16_t okj_count_elements(OkJsonParser *parser);
+
+/**
+ * @brief Print a human-readable debug dump of every token in @p parser to
+ *        stdout.  Only available when compiled with -DOK_JSON_DEBUG.
+ * @param parser Pointer to the main ok_json parser object
+ **/
+#ifdef OK_JSON_DEBUG
+void okj_debug_print(OkJsonParser *parser);
+#endif /* OK_JSON_DEBUG */
 
 #endif  /* OK_JSON_H */

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -221,6 +221,84 @@ static uint16_t okj_count_object_members(const char *start)
     return count;
 }
 
+/* Measure the full byte length of a JSON array or object starting at `start`
+ * (which must point to '[' or '{').  Returns the count of bytes from the
+ * opening bracket to the matching closing bracket, inclusive.  String content
+ * is skipped so that structural characters inside quoted values are ignored.
+ * Returns 0 if `start` is NULL or does not begin with '[' or '{'. */
+static uint16_t okj_measure_container(const char *start)
+{
+    uint16_t    depth  = 0U;
+    uint16_t    length = 0U;
+    const char *p      = start;
+
+    if ((p == NULL) || ((*p != '[') && (*p != '{')))
+    {
+        return 0U;
+    }
+
+    while (*p != '\0')
+    {
+        char c = *p;
+        length++;
+
+        if (c == '"')
+        {
+            /* Skip past the opening quote (already counted above). */
+            p++;
+
+            while ((*p != '\0') && (*p != '"'))
+            {
+                if (*p == '\\')
+                {
+                    p++;
+                    if (*p != '\0')
+                    {
+                        length++;
+                        p++;
+                    }
+                }
+                else
+                {
+                    p++;
+                }
+                length++;
+            }
+
+            /* Count the closing quote if present, then continue. */
+            if (*p == '"')
+            {
+                length++;
+                p++;
+            }
+        }
+        else
+        {
+            if ((c == '[') || (c == '{'))
+            {
+                depth++;
+            }
+            else if ((c == ']') || (c == '}'))
+            {
+                depth--;
+            }
+            else
+            {
+                /* whitespace, digits, colons, commas, letters, etc. */
+            }
+
+            p++;
+
+            if (depth == 0U)
+            {
+                break;
+            }
+        }
+    }
+
+    return length;
+}
+
 /* ---------------------------------------------------------------------------
  * File-scope result structs returned by getter functions.
  * Avoids dynamic allocation (suitable for embedded targets).
@@ -231,6 +309,8 @@ static OkJsonNumber  s_number_result;
 static OkJsonBoolean s_boolean_result;
 static OkJsonArray   s_array_result;
 static OkJsonObject  s_object_result;
+static OkJsonArray   s_full_array_result;
+static OkJsonObject  s_full_object_result;
 
 /* ---------------------------------------------------------------------------
  * Public API
@@ -578,8 +658,9 @@ OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)
         return NULL;
     }
 
-    s_array_result.start = parser->tokens[idx].start;
-    s_array_result.count = okj_count_array_elements(parser->tokens[idx].start);
+    s_array_result.start  = parser->tokens[idx].start;
+    s_array_result.count  = okj_count_array_elements(parser->tokens[idx].start);
+    s_array_result.length = okj_measure_container(parser->tokens[idx].start);
 
     if (s_array_result.count > OKJ_MAX_ARRAY_SIZE)
     {
@@ -605,8 +686,9 @@ OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)
         return NULL;
     }
 
-    s_object_result.start = parser->tokens[idx].start;
-    s_object_result.count = okj_count_object_members(parser->tokens[idx].start);
+    s_object_result.start  = parser->tokens[idx].start;
+    s_object_result.count  = okj_count_object_members(parser->tokens[idx].start);
+    s_object_result.length = okj_measure_container(parser->tokens[idx].start);
 
     if (s_object_result.count > OKJ_MAX_OBJECT_SIZE)
     {
@@ -634,3 +716,176 @@ OkJsonToken *okj_get_token(OkJsonParser *parser, const char *key)
 
     return &parser->tokens[idx];
 }
+
+OkJsonArray *okj_get_array_raw(OkJsonParser *parser, const char *key)
+{
+    uint16_t idx = 0U;
+
+    if ((parser == NULL) || (key == NULL))
+    {
+        return NULL;
+    }
+
+    idx = okj_find_value_index(parser, key);
+
+    if ((idx == OKJ_MAX_TOKENS) || (parser->tokens[idx].type != OKJ_ARRAY))
+    {
+        return NULL;
+    }
+
+    s_full_array_result.start  = parser->tokens[idx].start;
+    s_full_array_result.count  = okj_count_array_elements(parser->tokens[idx].start);
+    s_full_array_result.length = okj_measure_container(parser->tokens[idx].start);
+
+    return &s_full_array_result;
+}
+
+OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key)
+{
+    uint16_t idx = 0U;
+
+    if ((parser == NULL) || (key == NULL))
+    {
+        return NULL;
+    }
+
+    idx = okj_find_value_index(parser, key);
+
+    if ((idx == OKJ_MAX_TOKENS) || (parser->tokens[idx].type != OKJ_OBJECT))
+    {
+        return NULL;
+    }
+
+    s_full_object_result.start  = parser->tokens[idx].start;
+    s_full_object_result.count  = okj_count_object_members(parser->tokens[idx].start);
+    s_full_object_result.length = okj_measure_container(parser->tokens[idx].start);
+
+    return &s_full_object_result;
+}
+
+uint16_t okj_count_objects(OkJsonParser *parser)
+{
+    uint16_t count = 0U;
+    uint16_t i;
+
+    if (parser == NULL)
+    {
+        return 0U;
+    }
+
+    for (i = 0U; i < parser->token_count; i++)
+    {
+        if (parser->tokens[i].type == OKJ_OBJECT)
+        {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+uint16_t okj_count_arrays(OkJsonParser *parser)
+{
+    uint16_t count = 0U;
+    uint16_t i;
+
+    if (parser == NULL)
+    {
+        return 0U;
+    }
+
+    for (i = 0U; i < parser->token_count; i++)
+    {
+        if (parser->tokens[i].type == OKJ_ARRAY)
+        {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+uint16_t okj_count_elements(OkJsonParser *parser)
+{
+    if (parser == NULL)
+    {
+        return 0U;
+    }
+
+    return parser->token_count;
+}
+
+/* ---------------------------------------------------------------------------
+ * Debug print — only compiled when OK_JSON_DEBUG is defined
+ * ---------------------------------------------------------------------------*/
+
+#ifdef OK_JSON_DEBUG
+
+#include <stdio.h>
+
+static const char *okj_type_name(OkJsonType t)
+{
+    const char *name;
+
+    switch (t)
+    {
+        case OKJ_UNDEFINED: name = "UNDEFINED"; break;
+        case OKJ_OBJECT:    name = "OBJECT";    break;
+        case OKJ_ARRAY:     name = "ARRAY";     break;
+        case OKJ_STRING:    name = "STRING";    break;
+        case OKJ_NUMBER:    name = "NUMBER";    break;
+        case OKJ_BOOLEAN:   name = "BOOLEAN";   break;
+        case OKJ_NULL:      name = "NULL";      break;
+        default:            name = "UNKNOWN";   break;
+    }
+
+    return name;
+}
+
+void okj_debug_print(OkJsonParser *parser)
+{
+    uint16_t i;
+
+    if (parser == NULL)
+    {
+        (void)printf("okj_debug_print: NULL parser\n");
+        return;
+    }
+
+    (void)printf("=== OK_JSON Debug Dump: %u token(s) ===\n",
+                 (unsigned int)parser->token_count);
+
+    for (i = 0U; i < parser->token_count; i++)
+    {
+        OkJsonToken *t    = &parser->tokens[i];
+        uint16_t     dlen = t->length;
+        uint16_t     j;
+
+        if ((t->type == OKJ_OBJECT) || (t->type == OKJ_ARRAY))
+        {
+            dlen = okj_measure_container(t->start);
+        }
+
+        (void)printf("[%3u] type=%-9s len=%3u  val='",
+                     (unsigned int)i,
+                     okj_type_name(t->type),
+                     (unsigned int)dlen);
+
+        if (t->start != NULL)
+        {
+            for (j = 0U; j < dlen; j++)
+            {
+                if (t->start[j] == '\0')
+                {
+                    break;
+                }
+
+                (void)putchar((int)(unsigned char)t->start[j]);
+            }
+        }
+
+        (void)printf("'\n");
+    }
+}
+
+#endif /* OK_JSON_DEBUG */

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -49,6 +49,12 @@ void test_escaped_quote_in_string(void);
 void test_escaped_backslash_in_string(void);
 void test_array_too_large(void);
 void test_object_too_large(void);
+void test_get_array_raw(void);
+void test_get_object_raw(void);
+void test_count_objects(void);
+void test_count_arrays(void);
+void test_count_elements(void);
+void test_debug_print(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -585,6 +591,123 @@ void test_object_too_large(void)
     printf("test_object_too_large passed!\n");
 }
 
+void test_get_array_raw(void)
+{
+    /* Parse an object containing an array and verify that okj_get_array_raw()
+     * returns the correct element count AND the full raw byte length of the
+     * array text (including surrounding brackets). */
+
+    OkJsonParser parser;
+    OkJsonArray *arr;
+
+    /* "[1, 2, 3]" = 9 bytes */
+    char json_str[] = "{\"items\": [1, 2, 3]}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    arr = okj_get_array_raw(&parser, "items");
+
+    assert(arr != NULL);
+    assert(arr->count  == 3U);
+    assert(arr->start[0] == '[');
+    assert(arr->length == 9U);   /* [1, 2, 3] = 9 bytes */
+
+    printf("test_get_array_raw passed!\n");
+}
+
+void test_get_object_raw(void)
+{
+    /* Parse an object containing a nested object and verify that
+     * okj_get_object_raw() returns the correct member count AND the full raw
+     * byte length of the object text (including surrounding braces). */
+
+    OkJsonParser  parser;
+    OkJsonObject *obj;
+
+    /* {"a": 1} = 8 bytes */
+    char json_str[] = "{\"info\": {\"a\": 1}}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    obj = okj_get_object_raw(&parser, "info");
+
+    assert(obj != NULL);
+    assert(obj->count  == 1U);
+    assert(obj->start[0] == '{');
+    assert(obj->length == 8U);   /* {"a": 1} = 8 bytes */
+
+    printf("test_get_object_raw passed!\n");
+}
+
+void test_count_objects(void)
+{
+    /* Parse a JSON value that contains two object tokens (one outer, one
+     * nested) and verify that okj_count_objects() returns 2. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"a\": {\"b\": 1}, \"c\": 2}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    assert(okj_count_objects(&parser) == 2U);
+
+    printf("test_count_objects passed!\n");
+}
+
+void test_count_arrays(void)
+{
+    /* Parse a JSON value that contains two array tokens and verify that
+     * okj_count_arrays() returns 2. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"x\": [1, 2], \"y\": [3]}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    assert(okj_count_arrays(&parser) == 2U);
+
+    printf("test_count_arrays passed!\n");
+}
+
+void test_count_elements(void)
+{
+    /* Parse a simple object and verify that okj_count_elements() equals the
+     * total token count: 1 object + 1 string key + 1 number value = 3. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"key\": 42}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    assert(okj_count_elements(&parser) == 3U);
+
+    printf("test_count_elements passed!\n");
+}
+
+void test_debug_print(void)
+{
+    /* Parse a JSON value and call okj_debug_print() to exercise the full
+     * token dump path.  Correctness is verified visually in the output;
+     * this test ensures no crash and no assertion failure. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"key\": 42, \"arr\": [1, 2]}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+#ifdef OK_JSON_DEBUG
+    okj_debug_print(&parser);
+#endif
+
+    printf("test_debug_print passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -610,6 +733,12 @@ int main(int argc, char* argv[])
     test_escaped_backslash_in_string();
     test_array_too_large();
     test_object_too_large();
+    test_get_array_raw();
+    test_get_object_raw();
+    test_count_objects();
+    test_count_arrays();
+    test_count_elements();
+    test_debug_print();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
New public API functions:
- okj_get_array_raw()   – returns full OkJsonArray with raw byte length,
                          no OKJ_MAX_ARRAY_SIZE enforcement
- okj_get_object_raw()  – returns full OkJsonObject with raw byte length,
                          no OKJ_MAX_OBJECT_SIZE enforcement
- okj_count_objects()   – total OKJ_OBJECT token count in parsed result
- okj_count_arrays()    – total OKJ_ARRAY token count in parsed result
- okj_count_elements()  – total token count (all types) in parsed result
- okj_debug_print()     – human-readable token dump to stdout
                          (compiled only with -DOK_JSON_DEBUG)

Supporting changes:
- Add uint16_t length field to OkJsonArray and OkJsonObject so callers can recover the full raw text extent of any container
- Add okj_measure_container() static helper that walks '[…]' or '{…}' and returns the byte count including enclosing brackets/braces
- Update existing okj_get_array() and okj_get_object() to populate the new length field for consistency
- Add -DOK_JSON_DEBUG to Makefile CFLAGS so the debug function is built and exercised in every make run
- Add six new test functions covering all new API additions (26 tests total, zero warnings with -Wall -Wextra -Werror -std=c99 -pedantic)

https://claude.ai/code/session_01WU7ZbEGWTphFDdQRcfY6bC