### PR TITLE
Add OKJ_MAX_JSON_LEN constant and enforce it in okj_parse()

### DIFF
--- a/include/ok_json.h
+++ b/include/ok_json.h
@@ -73,6 +73,13 @@ static const uint16_t OKJ_MAX_ARRAY_SIZE = 64U;
 static const uint16_t OKJ_MAX_OBJECT_SIZE = 32U;
 
 /**
+ * @brief Maximum length of the raw JSON input string in bytes (excluding the
+ * terminating NUL character).  Inputs longer than this are rejected by
+ * okj_parse() before any tokenisation begins.
+ **/
+static const uint16_t OKJ_MAX_JSON_LEN = 4096U;
+
+/**
  * @brief Array of all valid ASCII characters for string processing
  **/
 static const char OKJ_VALID_CHARS[96] = {
@@ -107,7 +114,8 @@ typedef enum
     OKJ_ERROR_NULL_PARSER_OBJ      = 13,
     OKJ_ERROR_INVALID_TYPE_ENUM    = 14,
     OKJ_ERROR_NO_FREE_SPACE        = 15,
-    OKJ_ERROR_PARSING_FAILED       = 16
+    OKJ_ERROR_PARSING_FAILED       = 16,
+    OKJ_ERROR_MAX_JSON_LEN_EXCEEDED = 17
 } OkjError;
 
 /**

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -512,11 +512,22 @@ static OkjError okj_parse_value(OkJsonParser *parser)
 
 OkjError okj_parse(OkJsonParser *parser)
 {
-    OkjError result = OKJ_SUCCESS;
+    OkjError result  = OKJ_SUCCESS;
+    uint16_t json_len = 0U;
 
     if (parser == NULL)
     {
         return OKJ_ERROR_BAD_POINTER;
+    }
+
+    while (parser->json[json_len] != '\0')
+    {
+        json_len++;
+
+        if (json_len > OKJ_MAX_JSON_LEN)
+        {
+            return OKJ_ERROR_MAX_JSON_LEN_EXCEEDED;
+        }
     }
 
     while ((parser->json[parser->position] != '\0') &&


### PR DESCRIPTION
Introduces a new compile-time constant OKJ_MAX_JSON_LEN (4096 bytes) in ok_json.h that caps the maximum raw JSON input length, consistent with the existing per-string, array, and object size limits.  okj_parse() now measures the input length before tokenisation begins and returns the new error code OKJ_ERROR_MAX_JSON_LEN_EXCEEDED (17) if the limit is breached, preventing the parser from walking arbitrarily long buffers on safety-critical targets.

https://claude.ai/code/session_011ivTN6vQfZ3n4uNJao9SEx