### PR TITLE
docs: add comprehensive local wiki and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Requires a C99-capable compiler. Tested with GCC using
 
 All limits are compile-time constants.
 
+## Wiki
+
+A full local wiki is available in the [`wiki/`](wiki/) directory:
+
+- [Home](wiki/Home.md)
+- [Project Overview](wiki/Project-Overview.md)
+- [Design Philosophy](wiki/Design-Philosophy.md)
+- [API Reference](wiki/API-Reference.md)
+- [Usage Guide](wiki/Usage-Guide.md)
+- [Development and Testing](wiki/Development-and-Testing.md)
+
 ## Contributing
 
 If you've found a bug or improvement, feel free to submit an update! Here's how:

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,100 @@
+# API Reference
+
+## Core data structures
+
+### `OkJsonParser`
+
+Holds parser state:
+
+- `tokens[OKJ_MAX_TOKENS]`: parsed token storage
+- `token_count`: number of valid tokens
+- `json`: pointer to source JSON text
+- `position`: parse cursor
+
+### `OkJsonToken`
+
+Generic token descriptor:
+
+- `type`: one of `OkJsonType`
+- `start`: pointer into source JSON buffer
+- `length`: token byte length
+
+### Typed wrappers
+
+- `OkJsonString`
+- `OkJsonNumber`
+- `OkJsonBoolean`
+- `OkJsonArray`
+- `OkJsonObject`
+
+These carry `start` and `length`; array/object wrappers also include `count`.
+
+## Enumerations
+
+### `OkJsonType`
+
+- `OKJ_UNDEFINED`
+- `OKJ_OBJECT`
+- `OKJ_ARRAY`
+- `OKJ_STRING`
+- `OKJ_NUMBER`
+- `OKJ_BOOLEAN`
+- `OKJ_NULL`
+
+### `OkjError`
+
+Main result/failure values returned by parse routines, including:
+
+- `OKJ_SUCCESS`
+- `OKJ_ERROR_SYNTAX`
+- `OKJ_ERROR_UNEXPECTED_END`
+- `OKJ_ERROR_MAX_TOKENS_EXCEEDED`
+- `OKJ_ERROR_MAX_STR_LEN_EXCEEDED`
+- `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`
+- plus validation errors for pointers/types/content.
+
+## Initialization and parse
+
+### `void okj_init(OkJsonParser *parser, char *json_string)`
+
+Initializes parser state and binds it to the caller-provided mutable JSON buffer.
+
+### `OkjError okj_parse(OkJsonParser *parser)`
+
+Tokenizes the current JSON text and returns status code.
+
+## Key-based getters
+
+Each getter searches for a key token (`OKJ_STRING`) and returns the immediate next token if type-compatible.
+
+- `OkJsonString *okj_get_string(OkJsonParser *parser, const char *key)`
+- `OkJsonNumber *okj_get_number(OkJsonParser *parser, const char *key)`
+- `OkJsonBoolean *okj_get_boolean(OkJsonParser *parser, const char *key)`
+- `OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)`
+- `OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)`
+- `OkJsonToken *okj_get_token(OkJsonParser *parser, const char *key)`
+
+### Raw container getters
+
+These return full container span metadata and do not enforce the standard array/object member count limits used by the non-raw getters:
+
+- `OkJsonArray *okj_get_array_raw(OkJsonParser *parser, const char *key)`
+- `OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key)`
+
+## Counting helpers
+
+- `uint16_t okj_count_objects(OkJsonParser *parser)`
+- `uint16_t okj_count_arrays(OkJsonParser *parser)`
+- `uint16_t okj_count_elements(OkJsonParser *parser)`
+
+## Debug support
+
+When compiled with `OK_JSON_DEBUG`:
+
+- `void okj_debug_print(OkJsonParser *parser)` prints token diagnostics.
+
+## Important usage notes
+
+1. Returned pointers in getter structs refer to the original input buffer.
+2. Getter return structs are static internal storage; copy values immediately if you need to retain multiple results robustly across calls.
+3. Missing key or type mismatch returns `NULL`.

--- a/wiki/Design-Philosophy.md
+++ b/wiki/Design-Philosophy.md
@@ -1,0 +1,47 @@
+# Design Philosophy
+
+## 1) Deterministic resource usage
+
+The parser is deliberately fixed-capacity: token storage is a static array in `OkJsonParser`, and size limits are compile-time constants. This avoids heap fragmentation and makes worst-case memory use easy to reason about.
+
+## 2) Minimal dependency surface
+
+The project intentionally avoids relying on common libc helpers for core parsing logic (`ctype`, `string`, `stdio` in parser core). Instead it uses local helper functions for character classification and literal matching, reducing platform assumptions.
+
+## 3) Safety-minded implementation style
+
+The code and comments emphasize practices aligned with safety-critical expectations:
+
+- explicit type widths,
+- conservative null checks,
+- bounded scans,
+- clear error enums,
+- straightforward control flow.
+
+`ok_json.h` also supports opting into `<stdint.h>` via `OK_JSON_USE_STDINT_H`, while otherwise defining fixed-width aliases locally.
+
+## 4) Token stream over full DOM/AST
+
+OK_JSON does not allocate a hierarchical in-memory tree. Instead it emits tokens and lets callers resolve keys and values from token order. This trades flexibility for simplicity and predictable memory.
+
+## 5) Practical parsing coverage
+
+The parser supports common JSON primitives but intentionally does not try to be a full RFC feature-complete engine.
+
+Known practical boundaries include:
+
+- Limited/strict handling around advanced escape forms and unicode sequences.
+- Numeric parsing focused on basic integer/decimal forms (not rich exponent handling).
+- Getter APIs optimized for key/value retrieval rather than arbitrary query language behavior.
+
+## 6) Clear diagnostics via error codes
+
+The `OkjError` enum provides explicit failure reasons (syntax, max lengths, token overflow, etc.) so callers can map parser outcomes to system-level responses.
+
+## Out of scope (current direction)
+
+Based on repository documentation and roadmap files, the project currently defers:
+
+- full MISRA certification/toolchain analysis,
+- deeper structural metadata tracking beyond the present token model,
+- broader JSON edge-case support expected from heavyweight parsers.

--- a/wiki/Development-and-Testing.md
+++ b/wiki/Development-and-Testing.md
@@ -1,0 +1,53 @@
+# Development, Testing, and CI
+
+## Repository layout
+
+- `include/ok_json.h` — public API and constants
+- `src/ok_json.c` — parser implementation
+- `test/ok_json_tests.c` — unit-style test cases
+- `test/ok_json_test_runner.c` — test entrypoint
+- `Makefile` — local build/test targets
+- `.github/workflows/ci.yml` — GitHub Actions CI
+
+## Build flags and style bias
+
+The Makefile uses strict warnings and C99 mode (`-Wall -Wextra -Werror -pedantic` plus additional warning flags). This keeps parser changes disciplined and visible.
+
+`OK_JSON_DEBUG` is enabled in default CFLAGS, allowing debug-print helpers in local builds.
+
+## Test coverage themes
+
+Current tests validate:
+
+- parser init behavior and null handling,
+- simple object/array parsing,
+- strings, numbers, booleans, null,
+- type mismatch and missing key behavior in getters,
+- max token handling,
+- malformed/truncated input cases,
+- object/array getter behavior and helper counters.
+
+## Running checks locally
+
+```sh
+make clean
+make
+make test
+```
+
+The CI workflow additionally executes Valgrind over the test runner binary.
+
+## Extending the project safely
+
+When adding parser behavior:
+
+1. Add failing tests first in `test/ok_json_tests.c`.
+2. Keep limits explicit; avoid hidden dynamic allocation.
+3. Preserve pointer-slice semantics (`start`, `length`) unless intentionally redesigning API contracts.
+4. Update README and wiki pages to reflect any user-visible parsing rule changes.
+
+## Suggested future documentation additions
+
+- A formal compatibility matrix describing accepted vs rejected JSON constructs.
+- Examples for nested objects/arrays with raw getters.
+- A migration note if compile-time constants are ever made configurable via build flags.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,23 @@
+# OK_JSON Wiki
+
+Welcome to the project wiki for **OK_JSON**, a small, dependency-minimal JSON parser for C99 systems.
+
+This wiki is intended to serve as a practical replacement for a hosted project wiki and gathers architecture, API, usage, and development guidance in one place.
+
+## Pages
+
+- [Project Overview](./Project-Overview.md)
+- [Design Philosophy](./Design-Philosophy.md)
+- [API Reference](./API-Reference.md)
+- [Usage Guide](./Usage-Guide.md)
+- [Development, Testing, and CI](./Development-and-Testing.md)
+
+## Who this library is for
+
+OK_JSON is built for developers who need:
+
+- **Portable C99** code with no heavy runtime assumptions.
+- A **small parser footprint** with fixed memory usage.
+- A parser approach that is straightforward to review for embedded and safety-minded workflows.
+
+If your project needs full JSON features (extensive escape/unicode handling, rich numeric formats, dynamic AST allocation), this library may be intentionally too strict/minimal. See the “Out of Scope” section in [Design Philosophy](./Design-Philosophy.md).

--- a/wiki/Project-Overview.md
+++ b/wiki/Project-Overview.md
@@ -1,0 +1,69 @@
+# Project Overview
+
+## What OK_JSON is
+
+OK_JSON is a compact JSON tokenizer/parser library in C99 that parses an input JSON string into a fixed array of tokens stored inside `OkJsonParser`. It is designed for environments where predictability and low complexity are more important than complete JSON feature coverage.
+
+Core files:
+
+- Public API and types: `include/ok_json.h`
+- Implementation: `src/ok_json.c`
+- Tests: `test/ok_json_tests.c`, `test/ok_json_test_runner.c`
+- Build/test automation: `Makefile`, `.github/workflows/ci.yml`
+
+## Core capabilities
+
+- Parse JSON containing object, array, string, number, boolean, and null token types.
+- Store parser output in fixed-size token memory (`OKJ_MAX_TOKENS`) with no heap allocation.
+- Retrieve values by key from parsed objects via typed getters:
+  - `okj_get_string`
+  - `okj_get_number`
+  - `okj_get_boolean`
+  - `okj_get_array` / `okj_get_array_raw`
+  - `okj_get_object` / `okj_get_object_raw`
+  - `okj_get_token`
+- Count objects, arrays, and total tokens with helper functions.
+
+## Parser model at a glance
+
+OK_JSON is token-centric, not tree-centric:
+
+1. `okj_init()` binds parser state to a mutable JSON buffer.
+2. `okj_parse()` walks the input and appends tokens into `parser->tokens`.
+3. Getter functions scan token stream for key/value pairs and expose slices (`start`, `length`) into the original JSON string.
+
+Because tokens point into input memory, **the input buffer must remain valid for as long as retrieved values are used**.
+
+## Constraints and compile-time limits
+
+The parser intentionally relies on fixed limits for deterministic memory usage:
+
+- `OKJ_MAX_TOKENS`
+- `OKJ_MAX_STRING_LEN`
+- `OKJ_MAX_ARRAY_SIZE`
+- `OKJ_MAX_OBJECT_SIZE`
+- `OKJ_MAX_JSON_LEN`
+
+These controls are documented in the header and enforced by parsing/getter behavior.
+
+## Typical use case
+
+A common flow is:
+
+- parse a small telemetry or config object,
+- extract a few known keys,
+- avoid dynamic allocation and external library dependencies.
+
+Example (simplified):
+
+```c
+OkJsonParser parser;
+char json[] = "{\"temp\":42,\"ok\":true}";
+
+okj_init(&parser, json);
+if (okj_parse(&parser) == OKJ_SUCCESS) {
+    OkJsonNumber *temp = okj_get_number(&parser, "temp");
+    OkJsonBoolean *ok = okj_get_boolean(&parser, "ok");
+    /* Use temp->start/temp->length and ok->start/ok->length */
+}
+```

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -1,0 +1,61 @@
+# Usage Guide
+
+## Build
+
+```sh
+make
+make test
+```
+
+Artifacts:
+
+- `ok_json.a` static library
+- `test/ok_json_test_runner` test binary
+
+## Basic integration pattern
+
+```c
+#include "ok_json.h"
+
+OkJsonParser parser;
+char json[] = "{\"temp\":42,\"unit\":\"C\",\"valid\":true}";
+
+okj_init(&parser, json);
+if (okj_parse(&parser) == OKJ_SUCCESS) {
+    OkJsonNumber  *temp  = okj_get_number(&parser,  "temp");
+    OkJsonString  *unit  = okj_get_string(&parser,  "unit");
+    OkJsonBoolean *valid = okj_get_boolean(&parser, "valid");
+
+    if (temp != NULL) {
+        /* temp->start points to "42", temp->length == 2 */
+    }
+}
+```
+
+## Working with token slices
+
+Values are not copied into separate buffers. Instead, each result is a `(start, length)` view into the input JSON text.
+
+If you need null-terminated strings, copy them into your own destination buffer and append `\0`.
+
+## Error handling pattern
+
+Use `okj_parse()` result values to differentiate classes of failures:
+
+- syntax/format issue (`OKJ_ERROR_SYNTAX`, `OKJ_ERROR_BAD_NUMBER`, etc.),
+- resource/limit issue (`OKJ_ERROR_MAX_TOKENS_EXCEEDED`, `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`),
+- pointer or object misuse (`OKJ_ERROR_NULL_PARSER_OBJ`, `OKJ_ERROR_BAD_POINTER`).
+
+## Arrays and objects
+
+- `okj_get_array` / `okj_get_object` enforce size limits via `OKJ_MAX_ARRAY_SIZE` and `OKJ_MAX_OBJECT_SIZE`.
+- `okj_get_array_raw` / `okj_get_object_raw` return full span + counted members without those limit checks.
+
+Use raw variants when you need exact source span and can handle larger containers explicitly.
+
+## Pitfalls to avoid
+
+1. Passing string literals directly to APIs expecting mutable JSON buffers in systems that place literals in read-only memory.
+2. Freeing or overwriting the input buffer before consuming returned token pointers.
+3. Assuming getters perform type coercion; they require exact type match.
+4. Assuming full JSON escape/unicode semantics beyond current implementation scope.


### PR DESCRIPTION
### Motivation

- Provide a local, discoverable project wiki because the repository had no hosted wiki and README-level documentation was limited.  
- Consolidate design rationale, API details, usage examples, and developer/testing guidance for embedded/safety-minded users.  

### Description

- Added a `wiki/` directory with six pages: `Home.md`, `Project-Overview.md`, `Design-Philosophy.md`, `API-Reference.md`, `Usage-Guide.md`, and `Development-and-Testing.md`.  
- Updated `README.md` to include a **Wiki** section that links to all new wiki pages for discoverability.  
- The new docs cover project intent, token-based parser model, public API, compile-time limits, usage patterns, pitfalls, and recommended development/testing workflows.  

### Testing

- Built the project and ran the full test suite with `make clean && make test`, which completed successfully and reported all tests passed.  
- The test run includes the debug dump test and the test runner executed under the repository's normal build flags.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9f0029f24832fbff5137481e8f8a6)