### PR TITLE
Implement complete RFC 8259 number format parsing and tests

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -491,29 +491,99 @@ static OkjError okj_parse_value(OkJsonParser *parser)
     }
     else if ((okj_is_digit(c)) || (c == '-'))
     {
+        uint8_t number_ok = 1U;
+
         tok        = &parser->tokens[parser->token_count];
         tok->type  = OKJ_NUMBER;
         tok->start = &parser->json[parser->position];
 
         start_pos  = parser->position;
 
-        parser->position++;
-
-        while ((okj_is_digit(parser->json[parser->position])) ||
-               (parser->json[parser->position] == '.'))
+        /* Step 1: optional leading minus */
+        if (c == '-')
         {
-            parser->position++;
+            parser->position++;     /* consume '-' */
+
+            if (okj_is_digit(parser->json[parser->position]) == 0)
+            {
+                number_ok = 0U;     /* bare minus is not a valid number */
+            }
         }
 
-        if (parser->json[parser->position - 1U] == '.')
+        /* Step 2: integer part — zero OR digit1-9 *DIGIT */
+        if (number_ok != 0U)
         {
-            result = OKJ_ERROR_BAD_NUMBER;
+            if (parser->json[parser->position] == '0')
+            {
+                parser->position++;     /* consume '0' */
+
+                if (okj_is_digit(parser->json[parser->position]) != 0)
+                {
+                    number_ok = 0U;     /* leading zero: "012" is invalid */
+                }
+            }
+            else
+            {
+                while (okj_is_digit(parser->json[parser->position]) != 0)
+                {
+                    parser->position++;
+                }
+            }
         }
-        else
+
+        /* Step 3: optional fractional part — '.' 1*DIGIT */
+        if ((number_ok != 0U) && (parser->json[parser->position] == '.'))
+        {
+            parser->position++;     /* consume '.' */
+
+            if (okj_is_digit(parser->json[parser->position]) == 0)
+            {
+                number_ok = 0U;     /* decimal point must be followed by a digit */
+            }
+            else
+            {
+                while (okj_is_digit(parser->json[parser->position]) != 0)
+                {
+                    parser->position++;
+                }
+            }
+        }
+
+        /* Step 4: optional exponent part — ('e'/'E') [sign] 1*DIGIT */
+        if ((number_ok != 0U) &&
+            ((parser->json[parser->position] == 'e') ||
+             (parser->json[parser->position] == 'E')))
+        {
+            parser->position++;     /* consume 'e' or 'E' */
+
+            if ((parser->json[parser->position] == '+') ||
+                (parser->json[parser->position] == '-'))
+            {
+                parser->position++;     /* consume optional sign */
+            }
+
+            if (okj_is_digit(parser->json[parser->position]) == 0)
+            {
+                number_ok = 0U;     /* exponent requires at least one digit */
+            }
+            else
+            {
+                while (okj_is_digit(parser->json[parser->position]) != 0)
+                {
+                    parser->position++;
+                }
+            }
+        }
+
+        if (number_ok != 0U)
         {
             tok->length = parser->position - start_pos;
 
             parser->token_count++;
+        }
+        else
+        {
+            result = OKJ_ERROR_BAD_NUMBER;
         }
     }
     else if (okj_match(&parser->json[parser->position], "true", 4U))

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -36,6 +36,14 @@ void test_get_string(void);
 void test_invalid_string(void);
 void test_get_number(void);
 void test_invalid_number(void);
+void test_number_negative(void);
+void test_number_float(void);
+void test_number_exponent(void);
+void test_number_zero_variants(void);
+void test_number_invalid_lone_minus(void);
+void test_number_invalid_leading_zero(void);
+void test_number_invalid_trailing_decimal(void);
+void test_number_invalid_exponent_no_digits(void);
 void test_get_boolean_true(void);
 void test_get_boolean_false(void);
 void test_invalid_boolean(void);
@@ -211,6 +219,195 @@ void test_invalid_number(void)
     assert(num == NULL);
 
     printf("test_invalid_number passed!\n");
+}
+
+void test_number_negative(void)
+{
+    /* Parse a negative integer and verify the token covers the minus sign
+     * and both digits. */
+
+    OkJsonParser  parser;
+    OkJsonNumber *num;
+    char json_str[] = "{\"n\": -42}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 3U);      /* '-', '4', '2' */
+    assert(num->start[0] == '-');
+
+    printf("test_number_negative passed!\n");
+}
+
+void test_number_float(void)
+{
+    /* Parse positive and negative decimal numbers and verify token lengths. */
+
+    OkJsonParser  parser;
+    OkJsonNumber *num;
+    char json1[] = "{\"n\": 3.14}";
+    char json2[] = "{\"n\": -1.5}";
+
+    /* 3.14 */
+    okj_init(&parser, json1);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 4U);      /* '3', '.', '1', '4' */
+    assert(num->start[0] == '3');
+
+    /* -1.5 */
+    okj_init(&parser, json2);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 4U);      /* '-', '1', '.', '5' */
+    assert(num->start[0] == '-');
+
+    printf("test_number_float passed!\n");
+}
+
+void test_number_exponent(void)
+{
+    /* Parse numbers that use exponent notation (RFC 8259 §6).
+     * Both 'e' and 'E' forms, with and without an explicit sign, must
+     * be accepted and their full raw text captured in the token. */
+
+    OkJsonParser  parser;
+    OkJsonNumber *num;
+    char json1[] = "{\"n\": 1e10}";
+    char json2[] = "{\"n\": 2.5E-3}";
+    char json3[] = "{\"n\": 1E+2}";
+
+    /* 1e10 */
+    okj_init(&parser, json1);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 4U);      /* '1', 'e', '1', '0' */
+    assert(num->start[0] == '1');
+
+    /* 2.5E-3 */
+    okj_init(&parser, json2);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 6U);      /* '2', '.', '5', 'E', '-', '3' */
+    assert(num->start[0] == '2');
+
+    /* 1E+2 */
+    okj_init(&parser, json3);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 4U);      /* '1', 'E', '+', '2' */
+    assert(num->start[0] == '1');
+
+    printf("test_number_exponent passed!\n");
+}
+
+void test_number_zero_variants(void)
+{
+    /* Verify that bare zero and negative zero are both accepted. */
+
+    OkJsonParser  parser;
+    OkJsonNumber *num;
+    char json1[] = "{\"n\": 0}";
+    char json2[] = "{\"n\": -0}";
+
+    /* 0 */
+    okj_init(&parser, json1);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 1U);
+    assert(num->start[0] == '0');
+
+    /* -0 */
+    okj_init(&parser, json2);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    num = okj_get_number(&parser, "n");
+
+    assert(num != NULL);
+    assert(num->length == 2U);
+    assert(num->start[0] == '-');
+
+    printf("test_number_zero_variants passed!\n");
+}
+
+void test_number_invalid_lone_minus(void)
+{
+    /* A bare '-' with no following digits is not a valid JSON number. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"n\": -}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_ERROR_BAD_NUMBER);
+
+    printf("test_number_invalid_lone_minus passed!\n");
+}
+
+void test_number_invalid_leading_zero(void)
+{
+    /* RFC 8259 §6 forbids a leading zero followed by another digit.
+     * "012" must be rejected; "0" alone or "0.5" are valid. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"n\": 012}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_ERROR_BAD_NUMBER);
+
+    printf("test_number_invalid_leading_zero passed!\n");
+}
+
+void test_number_invalid_trailing_decimal(void)
+{
+    /* A decimal point must be followed by at least one digit.
+     * "1." is not a valid JSON number. */
+
+    OkJsonParser parser;
+    char json_str[] = "{\"n\": 1.}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_ERROR_BAD_NUMBER);
+
+    printf("test_number_invalid_trailing_decimal passed!\n");
+}
+
+void test_number_invalid_exponent_no_digits(void)
+{
+    /* An exponent marker ('e'/'E') must be followed by at least one digit
+     * (after an optional sign).  Both "1e" and "1e+" must be rejected. */
+
+    OkJsonParser parser;
+    char json1[] = "{\"n\": 1e}";
+    char json2[] = "{\"n\": 1e+}";
+
+    okj_init(&parser, json1);
+    assert(okj_parse(&parser) == OKJ_ERROR_BAD_NUMBER);
+
+    okj_init(&parser, json2);
+    assert(okj_parse(&parser) == OKJ_ERROR_BAD_NUMBER);
+
+    printf("test_number_invalid_exponent_no_digits passed!\n");
 }
 
 void test_get_boolean_true(void)
@@ -849,6 +1046,14 @@ int main(int argc, char* argv[])
     test_invalid_string();
     test_get_number();
     test_invalid_number();
+    test_number_negative();
+    test_number_float();
+    test_number_exponent();
+    test_number_zero_variants();
+    test_number_invalid_lone_minus();
+    test_number_invalid_leading_zero();
+    test_number_invalid_trailing_decimal();
+    test_number_invalid_exponent_no_digits();
     test_get_boolean_true();
     test_get_boolean_false();
     test_invalid_boolean();


### PR DESCRIPTION
The old number scanner was a single while-loop over digits and '.'. It silently accepted illegal inputs (lone '-', leading zeros like '012') and caused OKJ_ERROR_SYNTAX on valid exponent notation like '1e10'.

Replace with an explicit four-step grammar walk that matches RFC 8259 §6:
  number = [ minus ] int [ frac ] [ exp ]

Changes in src/ok_json.c:
- Step 1 (minus): consume '-' only when a digit follows; reject bare '-' with OKJ_ERROR_BAD_NUMBER
- Step 2 (int): accept '0' only when NOT followed by another digit (leading-zero rule); otherwise consume digit1-9 *DIGIT
- Step 3 (frac): if '.' present, require and consume 1+ digits after it
- Step 4 (exp): if 'e'/'E' present, consume optional sign then require and consume 1+ digits; reject 'e' or 'e+' with no digits

Valid formats now accepted: 0, -0, 42, -42, 3.14, -1.5, 1e10,
  2.5E-3, 1E+2, 0.5e2

Invalid formats now rejected: '-', '012', '1.', '1e', '1e+'

Changes in test/ok_json_tests.c — 8 new tests:
- test_number_negative: -42 accepted, length=3
- test_number_float: 3.14 and -1.5 accepted with correct lengths
- test_number_exponent: 1e10, 2.5E-3, 1E+2 all accepted
- test_number_zero_variants: 0 (length=1) and -0 (length=2) accepted
- test_number_invalid_lone_minus: '-' alone -> OKJ_ERROR_BAD_NUMBER
- test_number_invalid_leading_zero: '012' -> OKJ_ERROR_BAD_NUMBER
- test_number_invalid_trailing_decimal: '1.' -> OKJ_ERROR_BAD_NUMBER
- test_number_invalid_exponent_no_digits: '1e' and '1e+' -> OKJ_ERROR_BAD_NUMBER

All 40 tests pass under -Wall -Wextra -Werror -pedantic -std=c99.

https://claude.ai/code/session_01UZpNhYhgmEd893sSpBNi6P