### PR TITLE
Ensure all processed strings are null-terminated for safety

### DIFF
--- a/include/ok_json.h
+++ b/include/ok_json.h
@@ -311,6 +311,19 @@ OkJsonArray *okj_get_array_raw(OkJsonParser *parser, const char *key);
 OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key);
 
 /**
+ * @brief Copy a parsed string value into a caller-supplied buffer with
+ *        guaranteed null-termination.  At most @p buf_size - 1 bytes of
+ *        string content are copied; the buffer is always null-terminated
+ *        when @p buf_size >= 1.
+ * @param str      Pointer to an OkJsonString returned by okj_get_string()
+ * @param buf      Destination buffer supplied by the caller
+ * @param buf_size Total size of @p buf in bytes (must be >= 1)
+ * @return Number of characters copied (excluding the null terminator), or 0
+ *         on error (NULL inputs or buf_size == 0)
+ **/
+uint16_t okj_copy_string(const OkJsonString *str, char *buf, uint16_t buf_size);
+
+/**
  * @brief Return the total number of OKJ_OBJECT tokens in the parsed result.
  *        Counts every object opening brace that was tokenised, including
  *        nested objects.

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -684,7 +684,7 @@ static uint16_t okj_find_value_index(OkJsonParser *parser, const char *key)
     uint16_t i       = 0U;
     uint16_t key_len = 0U;
 
-    while (key[key_len] != '\0')
+    while ((key[key_len] != '\0') && (key_len <= OKJ_MAX_STRING_LEN))
     {
         key_len++;
     }
@@ -893,6 +893,34 @@ OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key)
     s_full_object_result.length = okj_measure_container(parser->tokens[idx].start);
 
     return &s_full_object_result;
+}
+
+uint16_t okj_copy_string(const OkJsonString *str, char *buf, uint16_t buf_size)
+{
+    uint16_t copy_len = 0U;
+    uint16_t i        = 0U;
+
+    if ((str == NULL) || (buf == NULL) || (buf_size == 0U))
+    {
+        return 0U;
+    }
+
+    /* Copy at most (buf_size - 1) bytes to leave room for the null terminator. */
+    copy_len = str->length;
+
+    if (copy_len >= buf_size)
+    {
+        copy_len = (uint16_t)(buf_size - 1U);
+    }
+
+    for (i = 0U; i < copy_len; i++)
+    {
+        buf[i] = str->start[i];
+    }
+
+    buf[copy_len] = '\0';
+
+    return copy_len;
 }
 
 uint16_t okj_count_objects(OkJsonParser *parser)

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -81,6 +81,12 @@ void test_deeply_nested_at_limit(void);
 void test_max_json_len_exceeded(void);
 void test_parse_null_parser(void);
 void test_truncated_backslash_at_eof(void);
+void test_copy_string_basic(void);
+void test_copy_string_null_terminated(void);
+void test_copy_string_truncation(void);
+void test_copy_string_exact_fit(void);
+void test_copy_string_null_inputs(void);
+void test_find_key_over_max_len(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -1415,6 +1421,183 @@ void test_truncated_backslash_at_eof(void)
     printf("test_truncated_backslash_at_eof passed!\n");
 }
 
+void test_copy_string_basic(void)
+{
+    /* Parse an object, retrieve a string, and verify that okj_copy_string()
+     * writes the correct content into the destination buffer. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+    char          buf[16];
+    uint16_t      copied;
+
+    char json_str[] = "{\"city\": \"Paris\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "city");
+    assert(str != NULL);
+
+    copied = okj_copy_string(str, buf, (uint16_t)sizeof(buf));
+
+    assert(copied == 5U);           /* "Paris" is 5 chars */
+    assert(buf[0] == 'P');
+    assert(buf[4] == 's');
+    assert(buf[5] == '\0');         /* must be null-terminated */
+
+    printf("test_copy_string_basic passed!\n");
+}
+
+void test_copy_string_null_terminated(void)
+{
+    /* Verify that the copied buffer is always null-terminated even when the
+     * source string fills the buffer to its last usable byte. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+    char          buf[6];           /* exactly room for "Paris" + NUL */
+    uint16_t      copied;
+
+    char json_str[] = "{\"city\": \"Paris\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "city");
+    assert(str != NULL);
+
+    copied = okj_copy_string(str, buf, (uint16_t)sizeof(buf));
+
+    assert(copied == 5U);
+    assert(buf[5] == '\0');         /* null terminator must be present */
+
+    printf("test_copy_string_null_terminated passed!\n");
+}
+
+void test_copy_string_truncation(void)
+{
+    /* When the destination buffer is smaller than the string, okj_copy_string()
+     * must copy only (buf_size - 1) bytes and still null-terminate. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+    char          buf[4];           /* only 3 chars fit + NUL */
+    uint16_t      copied;
+
+    char json_str[] = "{\"word\": \"Hello\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "word");
+    assert(str != NULL);
+    assert(str->length == 5U);
+
+    copied = okj_copy_string(str, buf, (uint16_t)sizeof(buf));
+
+    assert(copied == 3U);           /* only 3 chars copied */
+    assert(buf[0] == 'H');
+    assert(buf[1] == 'e');
+    assert(buf[2] == 'l');
+    assert(buf[3] == '\0');         /* must still be null-terminated */
+
+    printf("test_copy_string_truncation passed!\n");
+}
+
+void test_copy_string_exact_fit(void)
+{
+    /* A buffer of exactly (length + 1) bytes must hold the full string
+     * with no truncation and a null terminator at the final position. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+    char          buf[5];           /* "Hi" (2 chars) + NUL, extra space */
+    uint16_t      copied;
+
+    char json_str[] = "{\"k\": \"Hi\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "k");
+    assert(str != NULL);
+    assert(str->length == 2U);
+
+    /* buf_size == length + 1 == 3: exact fit */
+    copied = okj_copy_string(str, buf, 3U);
+
+    assert(copied == 2U);
+    assert(buf[0] == 'H');
+    assert(buf[1] == 'i');
+    assert(buf[2] == '\0');
+
+    printf("test_copy_string_exact_fit passed!\n");
+}
+
+void test_copy_string_null_inputs(void)
+{
+    /* okj_copy_string() must return 0 gracefully for all invalid arguments. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+    char          buf[8];
+    uint16_t      result;
+
+    char json_str[] = "{\"x\": \"abc\"}";
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "x");
+    assert(str != NULL);
+
+    /* NULL str pointer */
+    result = okj_copy_string(NULL, buf, (uint16_t)sizeof(buf));
+    assert(result == 0U);
+
+    /* NULL buf pointer */
+    result = okj_copy_string(str, NULL, (uint16_t)sizeof(buf));
+    assert(result == 0U);
+
+    /* buf_size == 0 */
+    result = okj_copy_string(str, buf, 0U);
+    assert(result == 0U);
+
+    printf("test_copy_string_null_inputs passed!\n");
+}
+
+void test_find_key_over_max_len(void)
+{
+    /* When okj_get_string() is called with a key that exceeds OKJ_MAX_STRING_LEN
+     * the lookup must return NULL rather than overreading the key buffer. */
+
+    OkJsonParser  parser;
+    OkJsonString *str;
+
+    /* JSON contains a short key "k" mapped to "v". */
+    char json_str[] = "{\"k\": \"v\"}";
+
+    /* A key string of 65 'k' characters (one beyond OKJ_MAX_STRING_LEN). */
+    char long_key[66];
+    uint16_t i;
+
+    for (i = 0U; i < 65U; i++)
+    {
+        long_key[i] = 'k';
+    }
+    long_key[65] = '\0';
+
+    okj_init(&parser, json_str);
+    assert(okj_parse(&parser) == OKJ_SUCCESS);
+
+    /* The long key cannot match the 1-char stored key; must return NULL. */
+    str = okj_get_string(&parser, long_key);
+    assert(str == NULL);
+
+    printf("test_find_key_over_max_len passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -1472,6 +1655,12 @@ int main(int argc, char* argv[])
     test_max_json_len_exceeded();
     test_parse_null_parser();
     test_truncated_backslash_at_eof();
+    test_copy_string_basic();
+    test_copy_string_null_terminated();
+    test_copy_string_truncation();
+    test_copy_string_exact_fit();
+    test_copy_string_null_inputs();
+    test_find_key_over_max_len();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
Three changes:

1. ok_json.c: add upper-bound guard to the key_len counting loop in okj_find_value_index().  Previously the loop scanned until '\0' with no limit, so a caller passing a non-null-terminated key buffer would cause an out-of-bounds read.  The loop now stops at OKJ_MAX_STRING_LEN + 1, which is one byte beyond the longest value any stored token can hold, so lookup behaviour is identical for valid inputs while overlong keys are safely rejected (returned length can never match a stored token).

2. ok_json.h / ok_json.c: add okj_copy_string() — a safe helper that copies an OkJsonString value into a caller-supplied buffer and always writes a null terminator.  Copies at most buf_size-1 content bytes, then appends '\0'.  Returns the number of characters copied, or 0 on bad arguments (NULL pointers, buf_size == 0).  This fills the gap where callers previously had to perform the copy-and-terminate dance themselves, with no library-provided safety net.

3. test/ok_json_tests.c: add six new tests covering the above:
   - test_copy_string_basic          — happy-path copy + content check
   - test_copy_string_null_terminated — explicit null-terminator check
   - test_copy_string_truncation     — buffer smaller than string
   - test_copy_string_exact_fit      — buffer exactly length+1 bytes
   - test_copy_string_null_inputs    — NULL str, NULL buf, buf_size==0
   - test_find_key_over_max_len      — key > OKJ_MAX_STRING_LEN returns NULL

All 56 tests pass with -Wall -Wextra -Werror -pedantic.

https://claude.ai/code/session_01RYgCNpDtJiR6nMTBXtGbgR