### PR TITLE
Add fixed-size depth/state stack with bracket matching and depth ceiling

### DIFF
--- a/include/ok_json.h
+++ b/include/ok_json.h
@@ -56,6 +56,15 @@ typedef unsigned char      uint8_t;
 #define OKJ_MAX_TOKENS 128U
 
 /**
+ * @brief Maximum nesting depth for JSON containers (objects and arrays).
+ * Defined as a preprocessor macro so it can be used as an array dimension in
+ * struct definitions.  The parser rejects input that would exceed this many
+ * concurrently open containers (RFC 8259 imposes no limit, but this bound
+ * protects embedded targets from unbounded stack growth).
+ **/
+#define OKJ_MAX_DEPTH 16U
+
+/**
  * @brief Maximum key or string length
  **/
 static const uint16_t OKJ_MAX_STRING_LEN = 64U;
@@ -115,7 +124,9 @@ typedef enum
     OKJ_ERROR_INVALID_TYPE_ENUM    = 14,
     OKJ_ERROR_NO_FREE_SPACE        = 15,
     OKJ_ERROR_PARSING_FAILED       = 16,
-    OKJ_ERROR_MAX_JSON_LEN_EXCEEDED = 17
+    OKJ_ERROR_MAX_JSON_LEN_EXCEEDED = 17,
+    OKJ_ERROR_MAX_DEPTH_EXCEEDED   = 18,
+    OKJ_ERROR_BRACKET_MISMATCH     = 19
 } OkjError;
 
 /**
@@ -195,9 +206,11 @@ typedef struct
 typedef struct
 {
     OkJsonToken tokens[OKJ_MAX_TOKENS];      /* Fixed-size token storage     */
-    uint16_t token_count;                    /* Number of parsed tokens      */
-    char *json;                              /* Pointer to input JSON string */
-    uint16_t position;                       /* Current parsing position     */
+    OkJsonType  depth_stack[OKJ_MAX_DEPTH];  /* Container-type at each depth */
+    uint16_t    token_count;                 /* Number of parsed tokens      */
+    uint16_t    depth;                       /* Current nesting depth        */
+    char       *json;                        /* Pointer to input JSON string */
+    uint16_t    position;                    /* Current parsing position     */
 } OkJsonParser;
 
 

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -337,9 +337,15 @@ void okj_init(OkJsonParser *parser, char *json_string)
             parser->tokens[i].length = 0U;
         }
 
+        for (i = 0U; i < (uint16_t)OKJ_MAX_DEPTH; i++)
+        {
+            parser->depth_stack[i] = OKJ_UNDEFINED;
+        }
+
         parser->json        = json_string;
         parser->position    = 0U;
         parser->token_count = 0U;
+        parser->depth       = 0U;
     }
 }
 
@@ -376,25 +382,61 @@ static OkjError okj_parse_value(OkJsonParser *parser)
     }
     else if (c == '{')
     {
+        if (parser->depth >= (uint16_t)OKJ_MAX_DEPTH)
+        {
+            return OKJ_ERROR_MAX_DEPTH_EXCEEDED;
+        }
+
         tok         = &parser->tokens[parser->token_count];
         tok->type   = OKJ_OBJECT;
         tok->start  = &parser->json[parser->position];
         tok->length = 1U;
+
+        parser->depth_stack[parser->depth] = OKJ_OBJECT;
+        parser->depth++;
         parser->position++;
         parser->token_count++;
     }
     else if (c == '[')
     {
+        if (parser->depth >= (uint16_t)OKJ_MAX_DEPTH)
+        {
+            return OKJ_ERROR_MAX_DEPTH_EXCEEDED;
+        }
+
         tok         = &parser->tokens[parser->token_count];
         tok->type   = OKJ_ARRAY;
         tok->start  = &parser->json[parser->position];
         tok->length = 1U;
 
+        parser->depth_stack[parser->depth] = OKJ_ARRAY;
+        parser->depth++;
         parser->position++;
         parser->token_count++;
     }
     else if ((c == '}') || (c == ']') || (c == ',') || (c == ':'))
     {
+        if ((c == '}') || (c == ']'))
+        {
+            /* Validate the closing bracket against the depth stack. */
+            if (parser->depth == 0U)
+            {
+                return OKJ_ERROR_BRACKET_MISMATCH;
+            }
+
+            parser->depth--;
+
+            if ((c == '}') && (parser->depth_stack[parser->depth] != OKJ_OBJECT))
+            {
+                return OKJ_ERROR_BRACKET_MISMATCH;
+            }
+
+            if ((c == ']') && (parser->depth_stack[parser->depth] != OKJ_ARRAY))
+            {
+                return OKJ_ERROR_BRACKET_MISMATCH;
+            }
+        }
+
         /* Structural punctuation — advance past it, emit no token. */
         parser->position++;
     }
@@ -668,6 +710,12 @@ OkjError okj_parse(OkJsonParser *parser)
         (parser->json[parser->position] != '\0'))
     {
         result = OKJ_ERROR_MAX_TOKENS_EXCEEDED;
+    }
+
+    /* Any containers still open at end-of-input indicate truncated input. */
+    if ((result == OKJ_SUCCESS) && (parser->depth != 0U))
+    {
+        result = OKJ_ERROR_UNEXPECTED_END;
     }
 
     return result;

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -87,6 +87,13 @@ void test_copy_string_truncation(void);
 void test_copy_string_exact_fit(void);
 void test_copy_string_null_inputs(void);
 void test_find_key_over_max_len(void);
+void test_depth_stack_bracket_mismatch_obj(void);
+void test_depth_stack_bracket_mismatch_arr(void);
+void test_depth_stack_extra_close_brace(void);
+void test_depth_stack_extra_close_bracket(void);
+void test_depth_stack_unclosed_object(void);
+void test_depth_stack_unclosed_array(void);
+void test_depth_stack_mixed_nesting(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -1286,73 +1293,73 @@ void test_key_65_chars_error(void)
 void test_deeply_nested_at_limit(void)
 {
     /* Build a deeply nested object: {"a":{"a":{"a":...{"a":1}...}}}
-     * with enough levels to push the token count beyond OKJ_MAX_TOKENS (128).
+     * and verify the depth-stack ceiling (OKJ_MAX_DEPTH) is enforced.
      *
      * Token count for N levels = 2*N + 1 (N objects + N string keys + 1 number).
-     * At N=63: 127 tokens  -> OKJ_SUCCESS
-     * At N=64: 129 tokens  -> OKJ_ERROR_MAX_TOKENS_EXCEEDED
-     *
-     * Both outcomes are deterministic and safe; neither is a crash or
-     * silent corruption. */
+     * At N = OKJ_MAX_DEPTH   (16): uses all 16 slots exactly -> OKJ_SUCCESS
+     * At N = OKJ_MAX_DEPTH+1 (17): opening the 17th '{' tries to push beyond
+     *                               the last slot -> OKJ_ERROR_MAX_DEPTH_EXCEEDED */
 
     OkJsonParser parser;
     OkjError     result;
+    uint16_t     i;
+    uint16_t     pos;
 
-    /* N=63: 63*5 + 1 + 63 = 379 chars + NUL = 380 bytes */
-    char json63[380];
-    uint16_t pos = 0U;
-    uint16_t i;
+    /* N=16: 16*5 + 1 + 16 = 97 chars + NUL = 98 bytes */
+    char json16[98];
+    pos = 0U;
 
-    for (i = 0U; i < 63U; i++)
+    for (i = 0U; i < 16U; i++)
     {
-        json63[pos++] = '{';
-        json63[pos++] = '"';
-        json63[pos++] = 'a';
-        json63[pos++] = '"';
-        json63[pos++] = ':';
+        json16[pos++] = '{';
+        json16[pos++] = '"';
+        json16[pos++] = 'a';
+        json16[pos++] = '"';
+        json16[pos++] = ':';
     }
 
-    json63[pos++] = '1';
+    json16[pos++] = '1';
 
-    for (i = 0U; i < 63U; i++)
+    for (i = 0U; i < 16U; i++)
     {
-        json63[pos++] = '}';
+        json16[pos++] = '}';
     }
 
-    json63[pos] = '\0';
+    json16[pos] = '\0';
 
-    okj_init(&parser, json63);
+    okj_init(&parser, json16);
     result = okj_parse(&parser);
 
     assert(result == OKJ_SUCCESS);
-    assert(parser.token_count == 127U);  /* 2*63 + 1 */
+    assert(parser.token_count == 33U);  /* 2*16 + 1 */
+    assert(parser.depth == 0U);         /* all containers closed */
 
-    /* N=64: 64*5 + 1 + 64 = 385 chars + NUL = 386 bytes */
-    char json64[386];
+    /* N=17: 17*5 + 1 + 17 = 103 chars + NUL = 104 bytes */
+    char json17[104];
     pos = 0U;
 
-    for (i = 0U; i < 64U; i++)
+    for (i = 0U; i < 17U; i++)
     {
-        json64[pos++] = '{';
-        json64[pos++] = '"';
-        json64[pos++] = 'a';
-        json64[pos++] = '"';
-        json64[pos++] = ':';
+        json17[pos++] = '{';
+        json17[pos++] = '"';
+        json17[pos++] = 'a';
+        json17[pos++] = '"';
+        json17[pos++] = ':';
     }
 
-    json64[pos++] = '1';
+    json17[pos++] = '1';
 
-    for (i = 0U; i < 64U; i++)
+    for (i = 0U; i < 17U; i++)
     {
-        json64[pos++] = '}';
+        json17[pos++] = '}';
     }
 
-    json64[pos] = '\0';
+    json17[pos] = '\0';
 
-    okj_init(&parser, json64);
+    okj_init(&parser, json17);
     result = okj_parse(&parser);
 
-    assert(result == OKJ_ERROR_MAX_TOKENS_EXCEEDED);
+    assert(result == OKJ_ERROR_MAX_DEPTH_EXCEEDED);
 
     printf("test_deeply_nested_at_limit passed!\n");
 }
@@ -1598,6 +1605,126 @@ void test_find_key_over_max_len(void)
     printf("test_find_key_over_max_len passed!\n");
 }
 
+void test_depth_stack_bracket_mismatch_obj(void)
+{
+    /* An object opened with '{' but closed with ']' must be rejected with
+     * OKJ_ERROR_BRACKET_MISMATCH rather than silently consuming the ']'. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"k\": 1]";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BRACKET_MISMATCH);
+
+    printf("test_depth_stack_bracket_mismatch_obj passed!\n");
+}
+
+void test_depth_stack_bracket_mismatch_arr(void)
+{
+    /* An array opened with '[' but closed with '}' must be rejected with
+     * OKJ_ERROR_BRACKET_MISMATCH. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "[1, 2}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BRACKET_MISMATCH);
+
+    printf("test_depth_stack_bracket_mismatch_arr passed!\n");
+}
+
+void test_depth_stack_extra_close_brace(void)
+{
+    /* A lone '}' with no matching '{' at depth 0 must be rejected with
+     * OKJ_ERROR_BRACKET_MISMATCH. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BRACKET_MISMATCH);
+
+    printf("test_depth_stack_extra_close_brace passed!\n");
+}
+
+void test_depth_stack_extra_close_bracket(void)
+{
+    /* A lone ']' with no matching '[' at depth 0 must be rejected with
+     * OKJ_ERROR_BRACKET_MISMATCH. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "]";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BRACKET_MISMATCH);
+
+    printf("test_depth_stack_extra_close_bracket passed!\n");
+}
+
+void test_depth_stack_unclosed_object(void)
+{
+    /* An object whose closing '}' is absent must be rejected.
+     * The depth check at end-of-input produces OKJ_ERROR_UNEXPECTED_END. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"key\": 42";   /* missing closing '}' */
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_UNEXPECTED_END);
+
+    printf("test_depth_stack_unclosed_object passed!\n");
+}
+
+void test_depth_stack_unclosed_array(void)
+{
+    /* An array whose closing ']' is absent must be rejected.
+     * The depth check at end-of-input produces OKJ_ERROR_UNEXPECTED_END. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "[1, 2, 3";   /* missing closing ']' */
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_UNEXPECTED_END);
+
+    printf("test_depth_stack_unclosed_array passed!\n");
+}
+
+void test_depth_stack_mixed_nesting(void)
+{
+    /* Verify that the stack correctly tracks alternating object/array
+     * container types: {"arr": [{"x": 1}]} */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"arr\": [{\"x\": 1}]}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_SUCCESS);
+    assert(parser.depth == 0U);   /* all containers closed */
+
+    printf("test_depth_stack_mixed_nesting passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -1661,6 +1788,13 @@ int main(int argc, char* argv[])
     test_copy_string_exact_fit();
     test_copy_string_null_inputs();
     test_find_key_over_max_len();
+    test_depth_stack_bracket_mismatch_obj();
+    test_depth_stack_bracket_mismatch_arr();
+    test_depth_stack_extra_close_brace();
+    test_depth_stack_extra_close_bracket();
+    test_depth_stack_unclosed_object();
+    test_depth_stack_unclosed_array();
+    test_depth_stack_mixed_nesting();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
Implements a 16-slot container-type stack (OKJ_MAX_DEPTH) inside OkJsonParser to enforce RFC 8259 structural correctness during parsing:

- Push OKJ_OBJECT / OKJ_ARRAY onto the stack when '{' / '[' is seen
- Pop and verify the matching container type on '}' / ']'; return OKJ_ERROR_BRACKET_MISMATCH if the types disagree or depth is 0
- Return OKJ_ERROR_MAX_DEPTH_EXCEEDED when a push would overflow the fixed-size stack (depth >= OKJ_MAX_DEPTH)
- Return OKJ_ERROR_UNEXPECTED_END after the parse loop if any containers remain open (depth != 0) — catches truncated input

New items in the public API:
- OKJ_MAX_DEPTH (preprocessor macro, value 16)
- OKJ_ERROR_MAX_DEPTH_EXCEEDED (error code 18)
- OKJ_ERROR_BRACKET_MISMATCH   (error code 19)
- depth_stack[OKJ_MAX_DEPTH] and depth fields in OkJsonParser

Tests: updated test_deeply_nested_at_limit to exercise the new depth ceiling; added 7 new tests covering bracket mismatch, extra closing brackets, unclosed containers, and correct mixed-nesting tracking. All 64 tests pass, zero compiler warnings.

https://claude.ai/code/session_01AzPtcR8ME7QAVT9woBuQ2a