### PR TITLE
Reject bare control characters in strings per RFC 8259 §7

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -506,6 +506,15 @@ static OkjError okj_parse_value(OkJsonParser *parser)
             }
             else
             {
+                /* RFC 8259 §7: bare control characters (U+0000–U+001F) are
+                 * forbidden inside strings; they must be represented as
+                 * escape sequences (e.g. \n, \t, \uXXXX). */
+                if ((unsigned char)parser->json[parser->position] < 0x20U)
+                {
+                    result = OKJ_ERROR_BAD_STRING;
+                    break;
+                }
+
                 parser->position++;
             }
         }


### PR DESCRIPTION
RFC 8259 §7 requires that control characters (U+0000–U+001F) inside JSON strings must be represented as escape sequences.  Previously the parser accepted them silently; now any unescaped byte < 0x20 encountered inside a string returns OKJ_ERROR_BAD_STRING immediately.

https://claude.ai/code/session_017e7kxm6aMqDYDJ9kH9LNYu