### PR TITLE
Validate single top-level value and reject trailing non-whitespace

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -685,8 +685,10 @@ static OkjError okj_parse_value(OkJsonParser *parser)
 
 OkjError okj_parse(OkJsonParser *parser)
 {
-    OkjError result  = OKJ_SUCCESS;
-    uint16_t json_len = 0U;
+    OkjError result      = OKJ_SUCCESS;
+    uint16_t json_len    = 0U;
+    uint16_t prev_tokens = 0U;
+    uint16_t prev_depth  = 0U;
 
     if (parser == NULL)
     {
@@ -706,11 +708,34 @@ OkjError okj_parse(OkJsonParser *parser)
     while ((parser->json[parser->position] != '\0') &&
            (parser->token_count < OKJ_MAX_TOKENS))
     {
+        prev_tokens = parser->token_count;
+        prev_depth  = parser->depth;
+
         result = okj_parse_value(parser);
 
         if (result != OKJ_SUCCESS)
         {
             break;
+        }
+
+        /* Detect completion of the single top-level value:
+         *  - A primitive was emitted at depth 0 (depth stayed 0, new token added), or
+         *  - A container was fully closed back to depth 0 (depth dropped from > 0).
+         * RFC 8259 §2 permits exactly one top-level value; anything other than
+         * optional whitespace that follows it is a syntax error. */
+        if (parser->depth == 0U)
+        {
+            if ((prev_depth > 0U) || (parser->token_count > prev_tokens))
+            {
+                okj_skip_whitespace(parser);
+
+                if (parser->json[parser->position] != '\0')
+                {
+                    result = OKJ_ERROR_SYNTAX;
+                }
+
+                break;
+            }
         }
     }
 

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -94,6 +94,12 @@ void test_depth_stack_extra_close_bracket(void);
 void test_depth_stack_unclosed_object(void);
 void test_depth_stack_unclosed_array(void);
 void test_depth_stack_mixed_nesting(void);
+void test_trailing_whitespace_after_object(void);
+void test_trailing_garbage_after_object(void);
+void test_trailing_garbage_after_array(void);
+void test_trailing_garbage_after_primitive(void);
+void test_two_top_level_primitives(void);
+void test_two_top_level_objects(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -1725,6 +1731,106 @@ void test_depth_stack_mixed_nesting(void)
     printf("test_depth_stack_mixed_nesting passed!\n");
 }
 
+void test_trailing_whitespace_after_object(void)
+{
+    /* Trailing whitespace after a valid top-level object must be accepted. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"x\": 1}   ";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_SUCCESS);
+
+    printf("test_trailing_whitespace_after_object passed!\n");
+}
+
+void test_trailing_garbage_after_object(void)
+{
+    /* Non-whitespace content after a complete top-level object must be
+     * rejected with OKJ_ERROR_SYNTAX. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"x\": 1} garbage";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_SYNTAX);
+
+    printf("test_trailing_garbage_after_object passed!\n");
+}
+
+void test_trailing_garbage_after_array(void)
+{
+    /* Non-whitespace content after a complete top-level array must be
+     * rejected with OKJ_ERROR_SYNTAX. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "[1, 2, 3] x";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_SYNTAX);
+
+    printf("test_trailing_garbage_after_array passed!\n");
+}
+
+void test_trailing_garbage_after_primitive(void)
+{
+    /* Non-whitespace content after a top-level primitive value must be
+     * rejected with OKJ_ERROR_SYNTAX. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "42 extra";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_SYNTAX);
+
+    printf("test_trailing_garbage_after_primitive passed!\n");
+}
+
+void test_two_top_level_primitives(void)
+{
+    /* Two consecutive top-level primitive values must be rejected because
+     * a JSON text contains exactly one top-level value (RFC 8259 §2). */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "true false";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_SYNTAX);
+
+    printf("test_two_top_level_primitives passed!\n");
+}
+
+void test_two_top_level_objects(void)
+{
+    /* Two consecutive top-level objects must be rejected. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{} {}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_SYNTAX);
+
+    printf("test_two_top_level_objects passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -1795,6 +1901,12 @@ int main(int argc, char* argv[])
     test_depth_stack_unclosed_object();
     test_depth_stack_unclosed_array();
     test_depth_stack_mixed_nesting();
+    test_trailing_whitespace_after_object();
+    test_trailing_garbage_after_object();
+    test_trailing_garbage_after_array();
+    test_trailing_garbage_after_primitive();
+    test_two_top_level_primitives();
+    test_two_top_level_objects();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
RFC 8259 §2 specifies that a JSON text consists of exactly one value. Previously okj_parse() would silently accept multiple consecutive top-level values or non-whitespace content after a valid value.

In okj_parse(), after each call to okj_parse_value(), detect when the single top-level value is complete (depth drops back to 0 after a container closes, or a token is emitted at depth 0 for a primitive). At that point skip any trailing whitespace and return OKJ_ERROR_SYNTAX if any non-whitespace character remains.

Six new tests cover: trailing whitespace after an object (accepted), trailing garbage after an object, array, and primitive (all rejected), and two consecutive top-level objects or primitives (both rejected).

https://claude.ai/code/session_01GvPfH4QN5Ef8VsH2XmEEDr