### PR TITLE
Enforce UTF-8 validity for RFC 8259 string parsing

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -48,6 +48,126 @@ static uint8_t okj_is_hex_digit(char c)
            ((c >= 'A') && (c <= 'F'));
 }
 
+static uint8_t okj_is_utf8_continuation(uint8_t byte)
+{
+    return (uint8_t)((byte & 0xC0U) == 0x80U);
+}
+
+/* Validate one UTF-8 scalar-value sequence starting at src[pos].
+ * On success sets *advance (1..4) and returns 1, else returns 0. */
+static uint8_t okj_validate_utf8_sequence(const char *src, uint16_t pos, uint16_t *advance)
+{
+    uint8_t b0;
+    uint8_t b1;
+    uint8_t b2;
+    uint8_t b3;
+
+    if ((src == NULL) || (advance == NULL))
+    {
+        return 0U;
+    }
+
+    b0 = (uint8_t)src[pos];
+
+    if (b0 <= 0x7FU)
+    {
+        *advance = 1U;
+        return 1U;
+    }
+
+    b1 = (uint8_t)src[pos + 1U];
+
+    if ((b0 >= 0xC2U) && (b0 <= 0xDFU))
+    {
+        if (okj_is_utf8_continuation(b1) != 0U)
+        {
+            *advance = 2U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    b2 = (uint8_t)src[pos + 2U];
+
+    if (b0 == 0xE0U)
+    {
+        if ((b1 >= 0xA0U) && (b1 <= 0xBFU) && (okj_is_utf8_continuation(b2) != 0U))
+        {
+            *advance = 3U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    if (((b0 >= 0xE1U) && (b0 <= 0xECU)) || ((b0 >= 0xEEU) && (b0 <= 0xEFU)))
+    {
+        if ((okj_is_utf8_continuation(b1) != 0U) &&
+            (okj_is_utf8_continuation(b2) != 0U))
+        {
+            *advance = 3U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    if (b0 == 0xEDU)
+    {
+        if ((b1 >= 0x80U) && (b1 <= 0x9FU) && (okj_is_utf8_continuation(b2) != 0U))
+        {
+            *advance = 3U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    b3 = (uint8_t)src[pos + 3U];
+
+    if (b0 == 0xF0U)
+    {
+        if ((b1 >= 0x90U) && (b1 <= 0xBFU) &&
+            (okj_is_utf8_continuation(b2) != 0U) &&
+            (okj_is_utf8_continuation(b3) != 0U))
+        {
+            *advance = 4U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    if ((b0 >= 0xF1U) && (b0 <= 0xF3U))
+    {
+        if ((okj_is_utf8_continuation(b1) != 0U) &&
+            (okj_is_utf8_continuation(b2) != 0U) &&
+            (okj_is_utf8_continuation(b3) != 0U))
+        {
+            *advance = 4U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    if (b0 == 0xF4U)
+    {
+        if ((b1 >= 0x80U) && (b1 <= 0x8FU) &&
+            (okj_is_utf8_continuation(b2) != 0U) &&
+            (okj_is_utf8_continuation(b3) != 0U))
+        {
+            *advance = 4U;
+            return 1U;
+        }
+
+        return 0U;
+    }
+
+    return 0U;
+}
+
 /* Returns 1 if the first `len` bytes of `src` equal `lit`, 0 otherwise.
  * Stops early on a NUL byte in `src` to avoid overreads. */
 static uint8_t okj_match(const char *src, const char *lit, uint16_t len)
@@ -631,6 +751,8 @@ static OkjError okj_parse_value(OkJsonParser *parser)
             }
             else
             {
+                uint16_t utf8_advance = 0U;
+
                 /* RFC 8259 §7: bare control characters (U+0000–U+001F) are
                  * forbidden inside strings; they must be represented as
                  * escape sequences (e.g. \n, \t, \uXXXX). */
@@ -640,7 +762,15 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                     break;
                 }
 
-                parser->position++;
+                if (okj_validate_utf8_sequence(parser->json,
+                                               parser->position,
+                                               &utf8_advance) == 0U)
+                {
+                    result = OKJ_ERROR_BAD_STRING;
+                    break;
+                }
+
+                parser->position += utf8_advance;
             }
         }
 

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -61,6 +61,10 @@ void test_escape_unicode_valid(void);
 void test_escape_unicode_invalid_hex(void);
 void test_escape_unicode_truncated(void);
 void test_escape_unknown(void);
+void test_utf8_valid_multibyte(void);
+void test_utf8_invalid_overlong(void);
+void test_utf8_invalid_surrogate(void);
+void test_utf8_invalid_truncated(void);
 void test_array_too_large(void);
 void test_object_too_large(void);
 void test_get_array_raw(void);
@@ -847,6 +851,76 @@ void test_escape_unknown(void)
     assert(okj_parse(&parser) == OKJ_ERROR_BAD_STRING);
 
     printf("test_escape_unknown passed!\n");
+}
+
+
+void test_utf8_valid_multibyte(void)
+{
+    /* RFC 8259 §8.1: UTF-8 encoded non-ASCII text in strings is valid. */
+
+    OkJsonParser  parser;
+    OkjError      result;
+    OkJsonString *str;
+    char json_str[] = "{\"s\":\"\xC3\xA9\xE6\xBC\xA2\xF0\x9F\x98\x80\"}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_SUCCESS);
+
+    str = okj_get_string(&parser, "s");
+    assert(str != NULL);
+    assert(str->length == 9U);  /* C3 A9 E6 BC A2 F0 9F 98 80 */
+
+    printf("test_utf8_valid_multibyte passed!\n");
+}
+
+void test_utf8_invalid_overlong(void)
+{
+    /* Overlong UTF-8 sequence (C0 AF) is forbidden by UTF-8 and RFC 8259 §8.1. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"s\":\"\xC0\xAF\"}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BAD_STRING);
+
+    printf("test_utf8_invalid_overlong passed!\n");
+}
+
+void test_utf8_invalid_surrogate(void)
+{
+    /* UTF-8 encoding of surrogate code point U+D800 (ED A0 80) is invalid. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"s\":\"\xED\xA0\x80\"}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BAD_STRING);
+
+    printf("test_utf8_invalid_surrogate passed!\n");
+}
+
+void test_utf8_invalid_truncated(void)
+{
+    /* Truncated UTF-8 leading byte (C2 without continuation) is invalid. */
+
+    OkJsonParser parser;
+    OkjError     result;
+    char json_str[] = "{\"s\":\"\xC2\"}";
+
+    okj_init(&parser, json_str);
+    result = okj_parse(&parser);
+
+    assert(result == OKJ_ERROR_BAD_STRING);
+
+    printf("test_utf8_invalid_truncated passed!\n");
 }
 
 void test_array_too_large(void)
@@ -2215,6 +2289,10 @@ int main(int argc, char* argv[])
     test_escape_unicode_invalid_hex();
     test_escape_unicode_truncated();
     test_escape_unknown();
+    test_utf8_valid_multibyte();
+    test_utf8_invalid_overlong();
+    test_utf8_invalid_surrogate();
+    test_utf8_invalid_truncated();
     test_array_too_large();
     test_object_too_large();
     test_get_array_raw();


### PR DESCRIPTION
### Motivation

- Ensure JSON string handling conforms to RFC 8259 §8.1 by rejecting ill-formed UTF-8 bytes in string contents.

### Description

- Added `okj_is_utf8_continuation()` and `okj_validate_utf8_sequence()` to validate single UTF-8 scalar sequences (1–4 bytes) and detect invalid forms such as overlong encodings, surrogate-range encodings, invalid continuation bytes, truncated sequences, and out-of-range 4-byte forms.
- Integrated UTF-8 validation into the string-parsing loop in `src/ok_json.c` so non-escaped non-ASCII bytes are checked and the parser advances by the validated byte length instead of assuming single-byte characters.
- On UTF-8 validation failure the parser now returns `OKJ_ERROR_BAD_STRING` for the offending string token.
- Added unit tests in `test/ok_json_tests.c`: `test_utf8_valid_multibyte`, `test_utf8_invalid_overlong`, `test_utf8_invalid_surrogate`, and `test_utf8_invalid_truncated` to cover valid multibyte text and representative invalid UTF-8 cases.

### Testing

- Built and ran the full test suite with `make`; the test runner executed and all tests passed including the new UTF-8 tests.
- Test files exercised: `test/ok_json_tests.c` (new UTF-8 cases) and `src/ok_json.c` (parser changes) and reported `All OK_JSON tests passed!` on the test runner output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d1327350832f9fa1d23b581eff4b)