### PR TITLE
docs(wiki): align documentation with current source code

### DIFF
--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -6,8 +6,11 @@
 
 Holds parser state:
 
-- `tokens[OKJ_MAX_TOKENS]`: parsed token storage
+- `tokens[OKJ_MAX_TOKENS]`: fixed-size parsed token storage
+- `depth_stack[OKJ_MAX_DEPTH]`: container type at each nesting depth (object or array)
+- `context`: current grammar expectation (`OkjParseContext`)
 - `token_count`: number of valid tokens
+- `depth`: current nesting depth
 - `json`: pointer to source JSON text
 - `position`: parse cursor
 
@@ -21,13 +24,14 @@ Generic token descriptor:
 
 ### Typed wrappers
 
-- `OkJsonString`
-- `OkJsonNumber`
-- `OkJsonBoolean`
-- `OkJsonArray`
-- `OkJsonObject`
+- `OkJsonString` — `start`, `length`
+- `OkJsonNumber` — `start`, `length`
+- `OkJsonBoolean` — `start`, `length`
+- `OkJsonArray` — `start`, `count`, `length`
+- `OkJsonObject` — `start`, `count`, `length`
 
-These carry `start` and `length`; array/object wrappers also include `count`.
+Array and object wrappers include a `count` of their members and a `length`
+covering the full raw text (including surrounding brackets/braces).
 
 ## Enumerations
 
@@ -41,60 +45,139 @@ These carry `start` and `length`; array/object wrappers also include `count`.
 - `OKJ_BOOLEAN`
 - `OKJ_NULL`
 
+### `OkjParseContext`
+
+Internal grammar state used during tokenisation (not normally inspected by
+callers, but visible in the struct):
+
+- `OKJ_CTX_WANT_VALUE` — expecting any JSON value
+- `OKJ_CTX_WANT_VALUE_OR_CLOSE` — expecting a value or `]` (just opened array)
+- `OKJ_CTX_WANT_KEY` — expecting an object key string
+- `OKJ_CTX_WANT_KEY_OR_CLOSE` — expecting a key string or `}` (just opened `{}`)
+- `OKJ_CTX_WANT_COLON` — expecting `:` after a key
+- `OKJ_CTX_WANT_SEP_OR_CLOSE` — expecting `,` or the matching close bracket
+
 ### `OkjError`
 
-Main result/failure values returned by parse routines, including:
+All result/failure codes returned by parse and getter routines:
 
-- `OKJ_SUCCESS`
-- `OKJ_ERROR_SYNTAX`
-- `OKJ_ERROR_UNEXPECTED_END`
-- `OKJ_ERROR_MAX_TOKENS_EXCEEDED`
-- `OKJ_ERROR_MAX_STR_LEN_EXCEEDED`
-- `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`
-- plus validation errors for pointers/types/content.
+| Code | Value | Meaning |
+|---|---|---|
+| `OKJ_SUCCESS` | 0 | Successful operation |
+| `OKJ_ERROR_INVALID_CHARACTER` | 1 | Unexpected character encountered |
+| `OKJ_ERROR_SYNTAX` | 2 | Structural syntax error |
+| `OKJ_ERROR_OVERFLOW` | 3 | Internal numeric overflow |
+| `OKJ_ERROR_UNEXPECTED_END` | 4 | Input ended prematurely |
+| `OKJ_ERROR_MAX_TOKENS_EXCEEDED` | 5 | Token array full (`OKJ_MAX_TOKENS`) |
+| `OKJ_ERROR_MAX_STR_LEN_EXCEEDED` | 6 | String exceeds `OKJ_MAX_STRING_LEN` |
+| `OKJ_ERROR_BAD_POINTER` | 7 | Unexpected NULL pointer argument |
+| `OKJ_ERROR_BAD_NUMBER` | 8 | Malformed numeric literal |
+| `OKJ_ERROR_BAD_OBJECT` | 9 | Malformed object |
+| `OKJ_ERROR_BAD_STRING` | 10 | Malformed string |
+| `OKJ_ERROR_BAD_ARRAY` | 11 | Malformed array |
+| `OKJ_ERROR_BAD_BOOLEAN` | 12 | Malformed boolean literal |
+| `OKJ_ERROR_NULL_PARSER_OBJ` | 13 | Parser pointer is NULL |
+| `OKJ_ERROR_INVALID_TYPE_ENUM` | 14 | Unrecognised `OkJsonType` value |
+| `OKJ_ERROR_NO_FREE_SPACE` | 15 | No space left in token array |
+| `OKJ_ERROR_PARSING_FAILED` | 16 | General parse failure |
+| `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED` | 17 | Input exceeds `OKJ_MAX_JSON_LEN` |
+| `OKJ_ERROR_MAX_DEPTH_EXCEEDED` | 18 | Nesting exceeds `OKJ_MAX_DEPTH` |
+| `OKJ_ERROR_BRACKET_MISMATCH` | 19 | Mismatched opening/closing brackets |
+
+## Compile-time and const limits
+
+| Constant | Default | Type | Description |
+|---|---|---|---|
+| `OKJ_MAX_TOKENS` | 128 | `#define` | Maximum number of tokens |
+| `OKJ_MAX_DEPTH` | 16 | `#define` | Maximum container nesting depth |
+| `OKJ_MAX_STRING_LEN` | 64 | `const uint16_t` | Maximum key/string length in bytes |
+| `OKJ_MAX_ARRAY_SIZE` | 64 | `const uint16_t` | Maximum array elements (non-raw getter) |
+| `OKJ_MAX_OBJECT_SIZE` | 32 | `const uint16_t` | Maximum object members (non-raw getter) |
+| `OKJ_MAX_JSON_LEN` | 4096 | `const uint16_t` | Maximum input JSON length in bytes |
 
 ## Initialization and parse
 
 ### `void okj_init(OkJsonParser *parser, char *json_string)`
 
-Initializes parser state and binds it to the caller-provided mutable JSON buffer.
+Initializes parser state and binds it to the caller-provided mutable JSON
+buffer.  The buffer must remain valid for the lifetime of any token pointers
+retrieved from the parser.
 
 ### `OkjError okj_parse(OkJsonParser *parser)`
 
-Tokenizes the current JSON text and returns status code.
+Tokenizes the bound JSON text and returns a status code.  On success,
+`parser->tokens` and `parser->token_count` are populated.
 
 ## Key-based getters
 
-Each getter searches for a key token (`OKJ_STRING`) and returns the immediate next token if type-compatible.
+Each getter scans for a `OKJ_STRING` token whose content matches `key`, then
+returns the immediately following token if the type matches.  All getters
+return `NULL` on a missing key, type mismatch, or bad argument.
 
-- `OkJsonString *okj_get_string(OkJsonParser *parser, const char *key)`
-- `OkJsonNumber *okj_get_number(OkJsonParser *parser, const char *key)`
+- `OkJsonString  *okj_get_string (OkJsonParser *parser, const char *key)`
+- `OkJsonNumber  *okj_get_number (OkJsonParser *parser, const char *key)`
 - `OkJsonBoolean *okj_get_boolean(OkJsonParser *parser, const char *key)`
-- `OkJsonArray *okj_get_array(OkJsonParser *parser, const char *key)`
-- `OkJsonObject *okj_get_object(OkJsonParser *parser, const char *key)`
-- `OkJsonToken *okj_get_token(OkJsonParser *parser, const char *key)`
+- `OkJsonArray   *okj_get_array  (OkJsonParser *parser, const char *key)`
+- `OkJsonObject  *okj_get_object (OkJsonParser *parser, const char *key)`
+- `OkJsonToken   *okj_get_token  (OkJsonParser *parser, const char *key)`
+
+`okj_get_array` and `okj_get_object` enforce `OKJ_MAX_ARRAY_SIZE` and
+`OKJ_MAX_OBJECT_SIZE` respectively and return `NULL` when the container
+exceeds the limit.
 
 ### Raw container getters
 
-These return full container span metadata and do not enforce the standard array/object member count limits used by the non-raw getters:
+These bypass the size limit checks and always populate the full `length` field:
 
-- `OkJsonArray *okj_get_array_raw(OkJsonParser *parser, const char *key)`
+- `OkJsonArray  *okj_get_array_raw (OkJsonParser *parser, const char *key)`
 - `OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key)`
+
+Use raw variants when you need the full source span of a large container.
+
+### String copy helper
+
+```c
+uint16_t okj_copy_string(const OkJsonString *str, char *buf, uint16_t buf_size);
+```
+
+Copies the parsed string value into `buf` with guaranteed null-termination.
+At most `buf_size - 1` bytes of content are copied.  Returns the number of
+characters copied (excluding the null terminator), or 0 on error.
+
+Because token `start` pointers are not null-terminated, use this helper
+whenever you need a C-string from a parsed string value.
 
 ## Counting helpers
 
-- `uint16_t okj_count_objects(OkJsonParser *parser)`
-- `uint16_t okj_count_arrays(OkJsonParser *parser)`
-- `uint16_t okj_count_elements(OkJsonParser *parser)`
+```c
+uint16_t okj_count_objects (const OkJsonParser *parser);
+uint16_t okj_count_arrays  (const OkJsonParser *parser);
+uint16_t okj_count_elements(const OkJsonParser *parser);
+```
+
+- `okj_count_objects` — total `OKJ_OBJECT` tokens (including nested)
+- `okj_count_arrays` — total `OKJ_ARRAY` tokens (including nested)
+- `okj_count_elements` — total token count; equivalent to `parser->token_count`
+
+All return 0 when `parser` is `NULL`.
 
 ## Debug support
 
-When compiled with `OK_JSON_DEBUG`:
+When compiled with `-DOK_JSON_DEBUG`:
 
-- `void okj_debug_print(OkJsonParser *parser)` prints token diagnostics.
+```c
+void okj_debug_print(OkJsonParser *parser);
+```
+
+Prints a human-readable dump of every token in `parser` to stdout.
 
 ## Important usage notes
 
-1. Returned pointers in getter structs refer to the original input buffer.
-2. Getter return structs are static internal storage; copy values immediately if you need to retain multiple results robustly across calls.
+1. Returned `start` pointers in getter structs point into the original input
+   buffer.  Do not free or overwrite the buffer while using those pointers.
+2. Getter return structs are backed by static internal storage; copy values
+   before making another getter call if you need multiple results concurrently.
 3. Missing key or type mismatch returns `NULL`.
+4. Getters do not perform type coercion; the next token must be the exact
+   requested type.
+5. Use `okj_copy_string()` to obtain null-terminated string values.

--- a/wiki/Design-Philosophy.md
+++ b/wiki/Design-Philosophy.md
@@ -2,15 +2,24 @@
 
 ## 1) Deterministic resource usage
 
-The parser is deliberately fixed-capacity: token storage is a static array in `OkJsonParser`, and size limits are compile-time constants. This avoids heap fragmentation and makes worst-case memory use easy to reason about.
+The parser is deliberately fixed-capacity: token storage is a static array in
+`OkJsonParser`, and size limits are compile-time constants.  This avoids heap
+fragmentation and makes worst-case memory use easy to reason about.
+
+The nesting depth is also bounded at compile time by `OKJ_MAX_DEPTH` (16),
+preventing unbounded stack growth on deeply nested input.
 
 ## 2) Minimal dependency surface
 
-The project intentionally avoids relying on common libc helpers for core parsing logic (`ctype`, `string`, `stdio` in parser core). Instead it uses local helper functions for character classification and literal matching, reducing platform assumptions.
+The project intentionally avoids relying on common libc helpers for core
+parsing logic (`ctype`, `string`, `stdio` in parser core).  Instead it uses
+local helper functions for character classification and literal matching,
+reducing platform assumptions.
 
 ## 3) Safety-minded implementation style
 
-The code and comments emphasize practices aligned with safety-critical expectations:
+The code and comments emphasize practices aligned with safety-critical
+expectations:
 
 - explicit type widths,
 - conservative null checks,
@@ -18,30 +27,48 @@ The code and comments emphasize practices aligned with safety-critical expectati
 - clear error enums,
 - straightforward control flow.
 
-`ok_json.h` also supports opting into `<stdint.h>` via `OK_JSON_USE_STDINT_H`, while otherwise defining fixed-width aliases locally.
+`ok_json.h` supports opting into `<stdint.h>` via `OK_JSON_USE_STDINT_H`,
+while otherwise defining fixed-width aliases locally (per MISRA C2012 Dir 4.6).
 
 ## 4) Token stream over full DOM/AST
 
-OK_JSON does not allocate a hierarchical in-memory tree. Instead it emits tokens and lets callers resolve keys and values from token order. This trades flexibility for simplicity and predictable memory.
+OK_JSON does not allocate a hierarchical in-memory tree.  Instead it emits
+tokens and lets callers resolve keys and values from token order.  This trades
+flexibility for simplicity and predictable memory.
 
 ## 5) Practical parsing coverage
 
-The parser supports common JSON primitives but intentionally does not try to be a full RFC feature-complete engine.
+The parser targets the common JSON constructs used in embedded/telemetry
+contexts, and validates input carefully within that scope:
 
-Known practical boundaries include:
+- **Strings**: full escape-sequence validation including `\"`, `\\`, `\/`,
+  `\b`, `\f`, `\n`, `\r`, `\t`, and `\uXXXX` (4-hex-digit Unicode escapes,
+  with surrogate-pair detection).  Raw multi-byte UTF-8 sequences are also
+  validated per the RFC 3629 encoding rules.
+- **Numbers**: integer, negative, decimal (`3.14`), and exponent forms
+  (`1e10`, `2.5E-3`) are accepted.  Degenerate forms such as a lone `-`,
+  leading zeros (e.g. `01`), trailing decimal points, and exponents without
+  digits are rejected.
+- **Structural validation**: trailing commas, mismatched brackets, extra
+  top-level values, and non-string object keys are all detected and rejected
+  with specific error codes.
 
-- Limited/strict handling around advanced escape forms and unicode sequences.
-- Numeric parsing focused on basic integer/decimal forms (not rich exponent handling).
-- Getter APIs optimized for key/value retrieval rather than arbitrary query language behavior.
+Getter APIs are optimised for key/value retrieval rather than arbitrary query
+language behaviour.
 
 ## 6) Clear diagnostics via error codes
 
-The `OkjError` enum provides explicit failure reasons (syntax, max lengths, token overflow, etc.) so callers can map parser outcomes to system-level responses.
+The `OkjError` enum provides explicit failure reasons (syntax, invalid
+character, bracket mismatch, max depth/length/token limits, etc.) so callers
+can map parser outcomes to system-level responses.  The full list of codes is
+in the [API Reference](./API-Reference.md).
 
 ## Out of scope (current direction)
 
-Based on repository documentation and roadmap files, the project currently defers:
+Based on repository documentation and roadmap files, the project currently
+defers:
 
 - full MISRA certification/toolchain analysis,
 - deeper structural metadata tracking beyond the present token model,
-- broader JSON edge-case support expected from heavyweight parsers.
+- JSON Pointer / JSONPath query language support,
+- number-to-native-type conversion (values are exposed as text slices).

--- a/wiki/Development-and-Testing.md
+++ b/wiki/Development-and-Testing.md
@@ -6,26 +6,58 @@
 - `src/ok_json.c` — parser implementation
 - `test/ok_json_tests.c` — unit-style test cases
 - `test/ok_json_test_runner.c` — test entrypoint
-- `Makefile` — local build/test targets
+- `Makefile` — local build/test/coverage targets
 - `.github/workflows/ci.yml` — GitHub Actions CI
 
 ## Build flags and style bias
 
-The Makefile uses strict warnings and C99 mode (`-Wall -Wextra -Werror -pedantic` plus additional warning flags). This keeps parser changes disciplined and visible.
+The Makefile uses strict warnings and C99 mode:
 
-`OK_JSON_DEBUG` is enabled in default CFLAGS, allowing debug-print helpers in local builds.
+```
+-Wall -Wextra -Werror -std=c99 -pedantic
+-Wconversion -Wsign-conversion -Wfloat-equal -Wcast-qual
+-Wcast-align -Wpointer-arith -Wshadow -Wlogical-op -Wundef
+-Wswitch-default -Wswitch-enum -Wunreachable-code
+```
+
+This keeps parser changes disciplined and visible.
+
+`-DOK_JSON_DEBUG` is enabled in default CFLAGS, enabling `okj_debug_print()`
+in local builds.
+
+## Makefile targets
+
+| Target | Description |
+|---|---|
+| `make` (or `make all`) | Builds `ok_json.a` and the test runner, then runs tests |
+| `make ok_json.a` | Builds the static library only |
+| `make test` | Builds and runs the test binary |
+| `make coverage` | Rebuilds with `--coverage`, runs tests, and generates `coverage.xml` via `gcovr` |
+| `make clean` | Removes all build artifacts including coverage data |
 
 ## Test coverage themes
 
 Current tests validate:
 
-- parser init behavior and null handling,
-- simple object/array parsing,
-- strings, numbers, booleans, null,
-- type mismatch and missing key behavior in getters,
-- max token handling,
-- malformed/truncated input cases,
-- object/array getter behavior and helper counters.
+- parser init behavior and null/bad-pointer handling
+- simple object and array parsing
+- strings, numbers (integer, negative, float, exponent), booleans, null
+- all supported escape sequences: `\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`
+- `\uXXXX` Unicode escapes including invalid hex, truncated sequences, and surrogate pairs
+- raw multi-byte UTF-8 sequence validation (2-, 3-, 4-byte) with MC/DC boundary coverage
+- type mismatch and missing key behavior in getters
+- max token exhaustion
+- malformed/truncated input cases
+- trailing commas, trailing garbage, and multiple top-level values
+- non-string object keys (number, boolean, null as key)
+- bracket mismatch and depth stack unwinding
+- object/array getter behavior (size limits, raw variants)
+- `okj_copy_string` behavior (basic copy, null termination, truncation, null inputs)
+- `okj_count_objects`, `okj_count_arrays`, `okj_count_elements` helper counters
+- key length boundary conditions (exactly 64 bytes vs. 65 bytes)
+- nesting depth limit (`OKJ_MAX_DEPTH`) and maximum JSON length limit
+- `okj_debug_print` output under `OK_JSON_DEBUG`
+- empty objects and arrays, nested objects and arrays
 
 ## Running checks locally
 
@@ -33,6 +65,12 @@ Current tests validate:
 make clean
 make
 make test
+```
+
+For line/branch coverage (requires `gcovr`):
+
+```sh
+make coverage
 ```
 
 The CI workflow additionally executes Valgrind over the test runner binary.
@@ -43,11 +81,6 @@ When adding parser behavior:
 
 1. Add failing tests first in `test/ok_json_tests.c`.
 2. Keep limits explicit; avoid hidden dynamic allocation.
-3. Preserve pointer-slice semantics (`start`, `length`) unless intentionally redesigning API contracts.
+3. Preserve pointer-slice semantics (`start`, `length`) unless intentionally
+   redesigning API contracts.
 4. Update README and wiki pages to reflect any user-visible parsing rule changes.
-
-## Suggested future documentation additions
-
-- A formal compatibility matrix describing accepted vs rejected JSON constructs.
-- Examples for nested objects/arrays with raw getters.
-- A migration note if compile-time constants are ever made configurable via build flags.

--- a/wiki/Project-Overview.md
+++ b/wiki/Project-Overview.md
@@ -22,6 +22,7 @@ Core files:
   - `okj_get_array` / `okj_get_array_raw`
   - `okj_get_object` / `okj_get_object_raw`
   - `okj_get_token`
+- Copy parsed string values into null-terminated buffers via `okj_copy_string`.
 - Count objects, arrays, and total tokens with helper functions.
 
 ## Parser model at a glance
@@ -38,11 +39,12 @@ Because tokens point into input memory, **the input buffer must remain valid for
 
 The parser intentionally relies on fixed limits for deterministic memory usage:
 
-- `OKJ_MAX_TOKENS`
-- `OKJ_MAX_STRING_LEN`
-- `OKJ_MAX_ARRAY_SIZE`
-- `OKJ_MAX_OBJECT_SIZE`
-- `OKJ_MAX_JSON_LEN`
+- `OKJ_MAX_TOKENS` (128) — maximum number of tokens
+- `OKJ_MAX_DEPTH` (16) — maximum container nesting depth
+- `OKJ_MAX_STRING_LEN` (64) — maximum key/string byte length
+- `OKJ_MAX_ARRAY_SIZE` (64) — maximum array elements (non-raw getter)
+- `OKJ_MAX_OBJECT_SIZE` (32) — maximum object members (non-raw getter)
+- `OKJ_MAX_JSON_LEN` (4096) — maximum input length in bytes
 
 These controls are documented in the header and enforced by parsing/getter behavior.
 

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -12,6 +12,12 @@ Artifacts:
 - `ok_json.a` static library
 - `test/ok_json_test_runner` test binary
 
+For coverage reporting (requires `gcovr`):
+
+```sh
+make coverage
+```
+
 ## Basic integration pattern
 
 ```c
@@ -34,28 +40,65 @@ if (okj_parse(&parser) == OKJ_SUCCESS) {
 
 ## Working with token slices
 
-Values are not copied into separate buffers. Instead, each result is a `(start, length)` view into the input JSON text.
+Values are not copied into separate buffers. Instead, each result is a
+`(start, length)` view into the input JSON text.  The `start` pointer is
+**not** null-terminated.
 
-If you need null-terminated strings, copy them into your own destination buffer and append `\0`.
+To obtain a null-terminated C string, use `okj_copy_string()`:
+
+```c
+OkJsonString *unit = okj_get_string(&parser, "unit");
+if (unit != NULL) {
+    char buf[65];
+    okj_copy_string(unit, buf, sizeof(buf));
+    /* buf now contains a null-terminated copy of the string value */
+}
+```
+
+`okj_copy_string` copies at most `buf_size - 1` bytes and always appends a
+null terminator when `buf_size >= 1`.  It returns the number of bytes copied
+(excluding the null terminator), or 0 on error.
 
 ## Error handling pattern
 
 Use `okj_parse()` result values to differentiate classes of failures:
 
-- syntax/format issue (`OKJ_ERROR_SYNTAX`, `OKJ_ERROR_BAD_NUMBER`, etc.),
-- resource/limit issue (`OKJ_ERROR_MAX_TOKENS_EXCEEDED`, `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`),
-- pointer or object misuse (`OKJ_ERROR_NULL_PARSER_OBJ`, `OKJ_ERROR_BAD_POINTER`).
+- syntax/format issues: `OKJ_ERROR_SYNTAX`, `OKJ_ERROR_BAD_NUMBER`,
+  `OKJ_ERROR_BAD_STRING`, `OKJ_ERROR_BAD_BOOLEAN`, `OKJ_ERROR_INVALID_CHARACTER`,
+  `OKJ_ERROR_TRAILING_CONTENT`
+- structural issues: `OKJ_ERROR_BRACKET_MISMATCH`, `OKJ_ERROR_UNEXPECTED_END`
+- resource/limit issues: `OKJ_ERROR_MAX_TOKENS_EXCEEDED`,
+  `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`, `OKJ_ERROR_MAX_DEPTH_EXCEEDED`,
+  `OKJ_ERROR_MAX_STR_LEN_EXCEEDED`
+- pointer or object misuse: `OKJ_ERROR_NULL_PARSER_OBJ`, `OKJ_ERROR_BAD_POINTER`
+
+See the full list of error codes in [API Reference](./API-Reference.md).
 
 ## Arrays and objects
 
-- `okj_get_array` / `okj_get_object` enforce size limits via `OKJ_MAX_ARRAY_SIZE` and `OKJ_MAX_OBJECT_SIZE`.
-- `okj_get_array_raw` / `okj_get_object_raw` return full span + counted members without those limit checks.
+- `okj_get_array` / `okj_get_object` enforce size limits via `OKJ_MAX_ARRAY_SIZE`
+  (64) and `OKJ_MAX_OBJECT_SIZE` (32) and return `NULL` when the container
+  exceeds the limit.
+- `okj_get_array_raw` / `okj_get_object_raw` return full span + counted members
+  without those limit checks.
 
-Use raw variants when you need exact source span and can handle larger containers explicitly.
+Use raw variants when you need the exact source span and can handle larger
+containers explicitly.
+
+## Nesting depth limit
+
+The parser enforces a maximum nesting depth of `OKJ_MAX_DEPTH` (16) for
+combined object and array containers.  Inputs that would exceed this are
+rejected with `OKJ_ERROR_MAX_DEPTH_EXCEEDED`.  This protects embedded targets
+from unbounded stack growth.
 
 ## Pitfalls to avoid
 
-1. Passing string literals directly to APIs expecting mutable JSON buffers in systems that place literals in read-only memory.
-2. Freeing or overwriting the input buffer before consuming returned token pointers.
-3. Assuming getters perform type coercion; they require exact type match.
-4. Assuming full JSON escape/unicode semantics beyond current implementation scope.
+1. Passing string literals directly to APIs expecting mutable JSON buffers in
+   systems that place literals in read-only memory.
+2. Freeing or overwriting the input buffer before consuming returned token
+   pointers.
+3. Assuming getters perform type coercion; they require an exact type match.
+4. Directly null-terminating `start`; use `okj_copy_string()` instead.
+5. Assuming all JSON escape sequences beyond the supported set are accepted;
+   see [Design Philosophy](./Design-Philosophy.md) for current scope.


### PR DESCRIPTION
- API-Reference: document all 19 OkjError codes, OkjParseContext enum, complete OkJsonParser struct fields (depth_stack, context, depth), correct const counting-helper signatures, add okj_copy_string(), add compile-time/const limits table, expand usage notes
- Project-Overview: add OKJ_MAX_DEPTH and okj_copy_string to capabilities and constraints sections; include default values
- Usage-Guide: add okj_copy_string usage with example, add nesting depth limit note, add coverage make target, expand error code list
- Design-Philosophy: correct section 5 — escape sequences (all \uXXXX, surrogates, raw UTF-8), exponent numbers, and structural validation are all well-supported; update out-of-scope list accordingly
- Development-and-Testing: add Makefile target table (coverage, clean), expand test coverage themes to include UTF-8 MC/DC, escape sequences, depth stack, bracket mismatch, okj_copy_string, trailing content tests; remove stale "suggested future additions" that are already done

https://claude.ai/code/session_01ASccZgimNfJoiAh3YtLMoK