### PR TITLE
docs: update API docs to reflect output-parameter getter signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,23 +24,29 @@ if (okj_parse(&parser) != OKJ_SUCCESS) {
     /* handle parse error */
 }
 
-/* 3. Retrieve scalar values by key */
-OkJsonNumber  *temp  = okj_get_number(&parser,  "temp");
-OkJsonString  *unit  = okj_get_string(&parser,  "unit");
-OkJsonBoolean *valid = okj_get_boolean(&parser, "valid");
+/* 3. Retrieve scalar values by key into caller-supplied structs */
+OkJsonNumber  temp;
+OkJsonString  unit;
+OkJsonBoolean valid;
 
-if (temp  != NULL) { /* temp->start points to "42", temp->length == 2  */ }
-if (unit  != NULL) { /* unit->start points to "C",  unit->length == 1  */ }
-if (valid != NULL) { /* valid->start points to "true", valid->length == 4 */ }
+if (okj_get_number (&parser, "temp",  &temp)  == OKJ_SUCCESS) {
+    /* temp.start points to "42", temp.length == 2 */
+}
+if (okj_get_string (&parser, "unit",  &unit)  == OKJ_SUCCESS) {
+    /* unit.start points to "C",  unit.length == 1 */
+}
+if (okj_get_boolean(&parser, "valid", &valid) == OKJ_SUCCESS) {
+    /* valid.start points to "true", valid.length == 4 */
+}
 
 /* 4. Copy a string value into a caller-supplied buffer */
 char buf[32];
-if (unit != NULL) {
-    okj_copy_string(unit, buf, sizeof(buf)); /* buf == "C\0" */
+if (okj_get_string(&parser, "unit", &unit) == OKJ_SUCCESS) {
+    okj_copy_string(&unit, buf, sizeof(buf)); /* buf == "C\0" */
 }
 ```
 
-All getter functions return `NULL` when the key is not found or when the value type does not match the requested type.
+All getter functions return an `OkjError` code and write their result into a caller-supplied struct.  They return an error code (not `OKJ_SUCCESS`) when the key is not found or the value type does not match.
 
 ## API Reference
 
@@ -53,16 +59,18 @@ All getter functions return `NULL` when the key is not found or when the value t
 
 ### Value Getters
 
-| Function | Returns |
-|----------|---------|
-| `okj_get_string(parser, key)` | `OkJsonString *` — quotes excluded |
-| `okj_get_number(parser, key)` | `OkJsonNumber *` — raw numeric text |
-| `okj_get_boolean(parser, key)` | `OkJsonBoolean *` — `"true"` or `"false"` literal |
-| `okj_get_array(parser, key)` | `OkJsonArray *` — enforces `OKJ_MAX_ARRAY_SIZE` |
-| `okj_get_object(parser, key)` | `OkJsonObject *` — enforces `OKJ_MAX_OBJECT_SIZE` |
-| `okj_get_array_raw(parser, key)` | `OkJsonArray *` — full raw array text, no size limit |
-| `okj_get_object_raw(parser, key)` | `OkJsonObject *` — full raw object text, no size limit |
-| `okj_get_token(parser, key)` | `OkJsonToken *` — raw token from the parser's token array |
+Each getter writes its result into a caller-supplied struct and returns an `OkjError` code.
+
+| Function | Out-param type | Notes |
+|----------|---------------|-------|
+| `okj_get_string(parser, key, out_str)` | `OkJsonString *` | quotes excluded |
+| `okj_get_number(parser, key, out_num)` | `OkJsonNumber *` | raw numeric text |
+| `okj_get_boolean(parser, key, out_bool)` | `OkJsonBoolean *` | `"true"` or `"false"` literal |
+| `okj_get_array(parser, key, out_arr)` | `OkJsonArray *` | enforces `OKJ_MAX_ARRAY_SIZE` |
+| `okj_get_object(parser, key, out_obj)` | `OkJsonObject *` | enforces `OKJ_MAX_OBJECT_SIZE` |
+| `okj_get_array_raw(parser, key, out_arr)` | `OkJsonArray *` | full raw array text, no size limit |
+| `okj_get_object_raw(parser, key, out_obj)` | `OkJsonObject *` | full raw object text, no size limit |
+| `okj_get_token(parser, key, out_tok)` | `OkJsonToken *` | raw token from the parser's token array |
 
 ### Utilities
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -110,29 +110,34 @@ Tokenizes the bound JSON text and returns a status code.  On success,
 
 ## Key-based getters
 
-Each getter scans for a `OKJ_STRING` token whose content matches `key`, then
-returns the immediately following token if the type matches.  All getters
-return `NULL` on a missing key, type mismatch, or bad argument.
+Each getter scans for an `OKJ_STRING` token whose content matches `key`, then
+writes the immediately following token into a caller-supplied output struct.
+All getters return `OkjError` — `OKJ_SUCCESS` on success, or the appropriate
+error code on a missing key, type mismatch, or bad argument.
 
-- `OkJsonString  *okj_get_string (OkJsonParser *parser, const char *key)`
-- `OkJsonNumber  *okj_get_number (OkJsonParser *parser, const char *key)`
-- `OkJsonBoolean *okj_get_boolean(OkJsonParser *parser, const char *key)`
-- `OkJsonArray   *okj_get_array  (OkJsonParser *parser, const char *key)`
-- `OkJsonObject  *okj_get_object (OkJsonParser *parser, const char *key)`
-- `OkJsonToken   *okj_get_token  (OkJsonParser *parser, const char *key)`
+```c
+OkjError okj_get_string (OkJsonParser *parser, const char *key, OkJsonString  *out_str);
+OkjError okj_get_number (OkJsonParser *parser, const char *key, OkJsonNumber  *out_num);
+OkjError okj_get_boolean(OkJsonParser *parser, const char *key, OkJsonBoolean *out_bool);
+OkjError okj_get_array  (OkJsonParser *parser, const char *key, OkJsonArray   *out_arr);
+OkjError okj_get_object (OkJsonParser *parser, const char *key, OkJsonObject  *out_obj);
+OkjError okj_get_token  (OkJsonParser *parser, const char *key, OkJsonToken   *out_tok);
+```
 
 `okj_get_array` and `okj_get_object` enforce `OKJ_MAX_ARRAY_SIZE` and
-`OKJ_MAX_OBJECT_SIZE` respectively and return `NULL` when the container
-exceeds the limit.
+`OKJ_MAX_OBJECT_SIZE` respectively and return `OKJ_ERROR_BAD_ARRAY` /
+`OKJ_ERROR_BAD_OBJECT` when the container exceeds the limit.
 
 ### Raw container getters
 
 These bypass the size limit checks and always populate the full `length` field:
 
-- `OkJsonArray  *okj_get_array_raw (OkJsonParser *parser, const char *key)`
-- `OkJsonObject *okj_get_object_raw(OkJsonParser *parser, const char *key)`
+```c
+OkjError okj_get_array_raw (OkJsonParser *parser, const char *key, OkJsonArray  *out_arr);
+OkjError okj_get_object_raw(OkJsonParser *parser, const char *key, OkJsonObject *out_obj);
+```
 
-Use raw variants when you need the full source span of a large container.
+Use raw variants when you need the exact source span of a large container.
 
 ### String copy helper
 
@@ -173,11 +178,14 @@ Prints a human-readable dump of every token in `parser` to stdout.
 
 ## Important usage notes
 
-1. Returned `start` pointers in getter structs point into the original input
-   buffer.  Do not free or overwrite the buffer while using those pointers.
-2. Getter return structs are backed by static internal storage; copy values
-   before making another getter call if you need multiple results concurrently.
-3. Missing key or type mismatch returns `NULL`.
-4. Getters do not perform type coercion; the next token must be the exact
-   requested type.
+1. The `start` pointer in every populated output struct points into the
+   original input buffer.  Do not free or overwrite the buffer while using
+   those pointers.
+2. Declare one output struct per value; getter functions write into the struct
+   you supply, so multiple results can coexist as long as you keep them in
+   separate variables.
+3. A missing key or type mismatch returns an error code (not `OKJ_SUCCESS`);
+   always check the return value before reading the output struct.
+4. Getters do not perform type coercion; the token immediately following the
+   key must be the exact requested type.
 5. Use `okj_copy_string()` to obtain null-terminated string values.

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -28,12 +28,18 @@ char json[] = "{\"temp\":42,\"unit\":\"C\",\"valid\":true}";
 
 okj_init(&parser, json);
 if (okj_parse(&parser) == OKJ_SUCCESS) {
-    OkJsonNumber  *temp  = okj_get_number(&parser,  "temp");
-    OkJsonString  *unit  = okj_get_string(&parser,  "unit");
-    OkJsonBoolean *valid = okj_get_boolean(&parser, "valid");
+    OkJsonNumber  temp;
+    OkJsonString  unit;
+    OkJsonBoolean valid;
 
-    if (temp != NULL) {
-        /* temp->start points to "42", temp->length == 2 */
+    if (okj_get_number (&parser, "temp",  &temp)  == OKJ_SUCCESS) {
+        /* temp.start points to "42", temp.length == 2 */
+    }
+    if (okj_get_string (&parser, "unit",  &unit)  == OKJ_SUCCESS) {
+        /* unit.start points to "C",  unit.length == 1 */
+    }
+    if (okj_get_boolean(&parser, "valid", &valid) == OKJ_SUCCESS) {
+        /* valid.start points to "true", valid.length == 4 */
     }
 }
 ```
@@ -47,10 +53,10 @@ Values are not copied into separate buffers. Instead, each result is a
 To obtain a null-terminated C string, use `okj_copy_string()`:
 
 ```c
-OkJsonString *unit = okj_get_string(&parser, "unit");
-if (unit != NULL) {
+OkJsonString unit;
+if (okj_get_string(&parser, "unit", &unit) == OKJ_SUCCESS) {
     char buf[65];
-    okj_copy_string(unit, buf, sizeof(buf));
+    okj_copy_string(&unit, buf, sizeof(buf));
     /* buf now contains a null-terminated copy of the string value */
 }
 ```
@@ -64,8 +70,7 @@ null terminator when `buf_size >= 1`.  It returns the number of bytes copied
 Use `okj_parse()` result values to differentiate classes of failures:
 
 - syntax/format issues: `OKJ_ERROR_SYNTAX`, `OKJ_ERROR_BAD_NUMBER`,
-  `OKJ_ERROR_BAD_STRING`, `OKJ_ERROR_BAD_BOOLEAN`, `OKJ_ERROR_INVALID_CHARACTER`,
-  `OKJ_ERROR_TRAILING_CONTENT`
+  `OKJ_ERROR_BAD_STRING`, `OKJ_ERROR_BAD_BOOLEAN`, `OKJ_ERROR_INVALID_CHARACTER`
 - structural issues: `OKJ_ERROR_BRACKET_MISMATCH`, `OKJ_ERROR_UNEXPECTED_END`
 - resource/limit issues: `OKJ_ERROR_MAX_TOKENS_EXCEEDED`,
   `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED`, `OKJ_ERROR_MAX_DEPTH_EXCEEDED`,
@@ -77,10 +82,10 @@ See the full list of error codes in [API Reference](./API-Reference.md).
 ## Arrays and objects
 
 - `okj_get_array` / `okj_get_object` enforce size limits via `OKJ_MAX_ARRAY_SIZE`
-  (64) and `OKJ_MAX_OBJECT_SIZE` (32) and return `NULL` when the container
-  exceeds the limit.
-- `okj_get_array_raw` / `okj_get_object_raw` return full span + counted members
-  without those limit checks.
+  (64) and `OKJ_MAX_OBJECT_SIZE` (32) and return `OKJ_ERROR_BAD_ARRAY` /
+  `OKJ_ERROR_BAD_OBJECT` when the container exceeds the limit.
+- `okj_get_array_raw` / `okj_get_object_raw` populate the full span + counted
+  members without those limit checks.
 
 Use raw variants when you need the exact source span and can handle larger
 containers explicitly.


### PR DESCRIPTION
All getter functions (okj_get_string, okj_get_number, okj_get_boolean, okj_get_array, okj_get_object, okj_get_token, okj_get_array_raw, okj_get_object_raw) were refactored from returning typed pointers to returning OkjError with a caller-supplied output struct parameter.

Update README.md, wiki/API-Reference.md, and wiki/Usage-Guide.md to:
- Show correct three-argument getter signatures with output params
- Replace NULL-return semantics with OkjError return code checks
- Fix code examples to declare structs and pass their addresses
- Remove OKJ_ERROR_TRAILING_CONTENT (not present in current OkjError enum)
- Clarify error codes returned on size-limit violations for array/object getters

https://claude.ai/code/session_01RqYVgHBmL952SnsPn57Qf9