### PR TITLE
docs: update all docs to reflect current function signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OkJsonParser parser;
 char json[] = "{\"temp\": 42, \"unit\": \"C\", \"valid\": true}";
 
 /* 2. Initialise and parse */
-okj_init(&parser, json);
+okj_init(&parser, json, (uint16_t)(sizeof(json) - 1U));
 if (okj_parse(&parser) != OKJ_SUCCESS) {
     /* handle parse error */
 }
@@ -29,19 +29,19 @@ OkJsonNumber  temp;
 OkJsonString  unit;
 OkJsonBoolean valid;
 
-if (okj_get_number (&parser, "temp",  &temp)  == OKJ_SUCCESS) {
+if (okj_get_number (&parser, "temp",  4U, &temp)  == OKJ_SUCCESS) {
     /* temp.start points to "42", temp.length == 2 */
 }
-if (okj_get_string (&parser, "unit",  &unit)  == OKJ_SUCCESS) {
+if (okj_get_string (&parser, "unit",  4U, &unit)  == OKJ_SUCCESS) {
     /* unit.start points to "C",  unit.length == 1 */
 }
-if (okj_get_boolean(&parser, "valid", &valid) == OKJ_SUCCESS) {
+if (okj_get_boolean(&parser, "valid", 5U, &valid) == OKJ_SUCCESS) {
     /* valid.start points to "true", valid.length == 4 */
 }
 
 /* 4. Copy a string value into a caller-supplied buffer */
 char buf[32];
-if (okj_get_string(&parser, "unit", &unit) == OKJ_SUCCESS) {
+if (okj_get_string(&parser, "unit", 4U, &unit) == OKJ_SUCCESS) {
     okj_copy_string(&unit, buf, sizeof(buf)); /* buf == "C\0" */
 }
 ```
@@ -54,7 +54,7 @@ All getter functions return an `OkjError` code and write their result into a cal
 
 | Function | Description |
 |----------|-------------|
-| `okj_init(parser, json_string)` | Initialise the parser with a mutable JSON string |
+| `okj_init(parser, json_string, json_len)` | Initialise the parser with a mutable JSON string and its byte length |
 | `okj_parse(parser)` | Tokenise the JSON string; returns `OkjError` |
 
 ### Value Getters
@@ -63,14 +63,14 @@ Each getter writes its result into a caller-supplied struct and returns an `OkjE
 
 | Function | Out-param type | Notes |
 |----------|---------------|-------|
-| `okj_get_string(parser, key, out_str)` | `OkJsonString *` | quotes excluded |
-| `okj_get_number(parser, key, out_num)` | `OkJsonNumber *` | raw numeric text |
-| `okj_get_boolean(parser, key, out_bool)` | `OkJsonBoolean *` | `"true"` or `"false"` literal |
-| `okj_get_array(parser, key, out_arr)` | `OkJsonArray *` | enforces `OKJ_MAX_ARRAY_SIZE` |
-| `okj_get_object(parser, key, out_obj)` | `OkJsonObject *` | enforces `OKJ_MAX_OBJECT_SIZE` |
-| `okj_get_array_raw(parser, key, out_arr)` | `OkJsonArray *` | full raw array text, no size limit |
-| `okj_get_object_raw(parser, key, out_obj)` | `OkJsonObject *` | full raw object text, no size limit |
-| `okj_get_token(parser, key, out_tok)` | `OkJsonToken *` | raw token from the parser's token array |
+| `okj_get_string(parser, key, key_len, out_str)` | `OkJsonString *` | quotes excluded |
+| `okj_get_number(parser, key, key_len, out_num)` | `OkJsonNumber *` | raw numeric text |
+| `okj_get_boolean(parser, key, key_len, out_bool)` | `OkJsonBoolean *` | `"true"` or `"false"` literal |
+| `okj_get_array(parser, key, key_len, out_arr)` | `OkJsonArray *` | enforces `OKJ_MAX_ARRAY_SIZE` |
+| `okj_get_object(parser, key, key_len, out_obj)` | `OkJsonObject *` | enforces `OKJ_MAX_OBJECT_SIZE` |
+| `okj_get_array_raw(parser, key, key_len, out_arr)` | `OkJsonArray *` | full raw array text, no size limit |
+| `okj_get_object_raw(parser, key, key_len, out_obj)` | `OkJsonObject *` | full raw object text, no size limit |
+| `okj_get_token(parser, key, key_len, out_tok)` | `OkJsonToken *` | raw token from the parser's token array |
 
 ### Utilities
 
@@ -108,9 +108,8 @@ Requires a C99-capable compiler. Tested with GCC using
 | `OKJ_MAX_OBJECT_SIZE` | 32      | Maximum object member count                  |
 | `OKJ_MAX_JSON_LEN`    | 4096    | Maximum raw JSON input length in bytes       |
 
-`OKJ_MAX_TOKENS` and `OKJ_MAX_DEPTH` are preprocessor macros (used as array
-dimensions in struct definitions). The remaining limits are `static const`
-values defined in the header. All can be overridden at compile time.
+All limits are preprocessor macros defined in the header and can be overridden
+at compile time by defining them before including `ok_json.h`.
 
 ## Wiki
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -12,6 +12,7 @@ Holds parser state:
 - `token_count`: number of valid tokens
 - `depth`: current nesting depth
 - `json`: pointer to source JSON text
+- `json_len`: byte length of the JSON string (excluding any null terminator)
 - `position`: parse cursor
 
 ### `OkJsonToken`
@@ -90,18 +91,19 @@ All result/failure codes returned by parse and getter routines:
 |---|---|---|---|
 | `OKJ_MAX_TOKENS` | 128 | `#define` | Maximum number of tokens |
 | `OKJ_MAX_DEPTH` | 16 | `#define` | Maximum container nesting depth |
-| `OKJ_MAX_STRING_LEN` | 64 | `const uint16_t` | Maximum key/string length in bytes |
-| `OKJ_MAX_ARRAY_SIZE` | 64 | `const uint16_t` | Maximum array elements (non-raw getter) |
-| `OKJ_MAX_OBJECT_SIZE` | 32 | `const uint16_t` | Maximum object members (non-raw getter) |
-| `OKJ_MAX_JSON_LEN` | 4096 | `const uint16_t` | Maximum input JSON length in bytes |
+| `OKJ_MAX_STRING_LEN` | 64 | `#define` | Maximum key/string length in bytes |
+| `OKJ_MAX_ARRAY_SIZE` | 64 | `#define` | Maximum array elements (non-raw getter) |
+| `OKJ_MAX_OBJECT_SIZE` | 32 | `#define` | Maximum object members (non-raw getter) |
+| `OKJ_MAX_JSON_LEN` | 4096 | `#define` | Maximum input JSON length in bytes |
 
 ## Initialization and parse
 
-### `void okj_init(OkJsonParser *parser, char *json_string)`
+### `void okj_init(OkJsonParser *parser, char *json_string, uint16_t json_len)`
 
 Initializes parser state and binds it to the caller-provided mutable JSON
-buffer.  The buffer must remain valid for the lifetime of any token pointers
-retrieved from the parser.
+buffer.  `json_len` is the byte length of `json_string` excluding any null
+terminator.  The buffer must remain valid for the lifetime of any token
+pointers retrieved from the parser.
 
 ### `OkjError okj_parse(OkJsonParser *parser)`
 
@@ -116,13 +118,15 @@ All getters return `OkjError` — `OKJ_SUCCESS` on success, or the appropriate
 error code on a missing key, type mismatch, or bad argument.
 
 ```c
-OkjError okj_get_string (OkJsonParser *parser, const char *key, OkJsonString  *out_str);
-OkjError okj_get_number (OkJsonParser *parser, const char *key, OkJsonNumber  *out_num);
-OkjError okj_get_boolean(OkJsonParser *parser, const char *key, OkJsonBoolean *out_bool);
-OkjError okj_get_array  (OkJsonParser *parser, const char *key, OkJsonArray   *out_arr);
-OkjError okj_get_object (OkJsonParser *parser, const char *key, OkJsonObject  *out_obj);
-OkjError okj_get_token  (OkJsonParser *parser, const char *key, OkJsonToken   *out_tok);
+OkjError okj_get_string (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonString  *out_str);
+OkjError okj_get_number (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonNumber  *out_num);
+OkjError okj_get_boolean(OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonBoolean *out_bool);
+OkjError okj_get_array  (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonArray   *out_arr);
+OkjError okj_get_object (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonObject  *out_obj);
+OkjError okj_get_token  (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonToken   *out_tok);
 ```
+
+`key_len` is the byte length of the key string (excluding any null terminator).
 
 `okj_get_array` and `okj_get_object` enforce `OKJ_MAX_ARRAY_SIZE` and
 `OKJ_MAX_OBJECT_SIZE` respectively and return `OKJ_ERROR_BAD_ARRAY` /
@@ -133,8 +137,8 @@ OkjError okj_get_token  (OkJsonParser *parser, const char *key, OkJsonToken   *o
 These bypass the size limit checks and always populate the full `length` field:
 
 ```c
-OkjError okj_get_array_raw (OkJsonParser *parser, const char *key, OkJsonArray  *out_arr);
-OkjError okj_get_object_raw(OkJsonParser *parser, const char *key, OkJsonObject *out_obj);
+OkjError okj_get_array_raw (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonArray  *out_arr);
+OkjError okj_get_object_raw(OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonObject *out_obj);
 ```
 
 Use raw variants when you need the exact source span of a large container.

--- a/wiki/Project-Overview.md
+++ b/wiki/Project-Overview.md
@@ -62,10 +62,15 @@ Example (simplified):
 OkJsonParser parser;
 char json[] = "{\"temp\":42,\"ok\":true}";
 
-okj_init(&parser, json);
+okj_init(&parser, json, (uint16_t)(sizeof(json) - 1U));
 if (okj_parse(&parser) == OKJ_SUCCESS) {
-    OkJsonNumber *temp = okj_get_number(&parser, "temp");
-    OkJsonBoolean *ok = okj_get_boolean(&parser, "ok");
-    /* Use temp->start/temp->length and ok->start/ok->length */
+    OkJsonNumber  temp;
+    OkJsonBoolean ok;
+    if (okj_get_number (&parser, "temp", 4U, &temp) == OKJ_SUCCESS) {
+        /* Use temp.start / temp.length */
+    }
+    if (okj_get_boolean(&parser, "ok",   2U, &ok)   == OKJ_SUCCESS) {
+        /* Use ok.start / ok.length */
+    }
 }
 ```

--- a/wiki/Usage-Guide.md
+++ b/wiki/Usage-Guide.md
@@ -26,19 +26,19 @@ make coverage
 OkJsonParser parser;
 char json[] = "{\"temp\":42,\"unit\":\"C\",\"valid\":true}";
 
-okj_init(&parser, json);
+okj_init(&parser, json, (uint16_t)(sizeof(json) - 1U));
 if (okj_parse(&parser) == OKJ_SUCCESS) {
     OkJsonNumber  temp;
     OkJsonString  unit;
     OkJsonBoolean valid;
 
-    if (okj_get_number (&parser, "temp",  &temp)  == OKJ_SUCCESS) {
+    if (okj_get_number (&parser, "temp",  4U, &temp)  == OKJ_SUCCESS) {
         /* temp.start points to "42", temp.length == 2 */
     }
-    if (okj_get_string (&parser, "unit",  &unit)  == OKJ_SUCCESS) {
+    if (okj_get_string (&parser, "unit",  4U, &unit)  == OKJ_SUCCESS) {
         /* unit.start points to "C",  unit.length == 1 */
     }
-    if (okj_get_boolean(&parser, "valid", &valid) == OKJ_SUCCESS) {
+    if (okj_get_boolean(&parser, "valid", 5U, &valid) == OKJ_SUCCESS) {
         /* valid.start points to "true", valid.length == 4 */
     }
 }
@@ -54,7 +54,7 @@ To obtain a null-terminated C string, use `okj_copy_string()`:
 
 ```c
 OkJsonString unit;
-if (okj_get_string(&parser, "unit", &unit) == OKJ_SUCCESS) {
+if (okj_get_string(&parser, "unit", 4U, &unit) == OKJ_SUCCESS) {
     char buf[65];
     okj_copy_string(&unit, buf, sizeof(buf));
     /* buf now contains a null-terminated copy of the string value */


### PR DESCRIPTION
After PR #57 added explicit length parameters to all string/key inputs, the docs still showed the old 2/3-param signatures. Update README, wiki API Reference, Usage Guide, and Project Overview to reflect:

- okj_init() now takes a third argument: uint16_t json_len
- All key-based getters now take uint16_t key_len between key and out-param
- Fix wiki/API-Reference.md: OkJsonParser struct missing json_len field
- Fix wiki/API-Reference.md: all limits are #define macros (not const uint16_t)
- Fix wiki/Project-Overview.md: example used old pointer-return style for getters
- Update README limits note: all limits are preprocessor macros

https://claude.ai/code/session_01KbVdde9hta9X9Qy43Si2j1