### PR TITLE
docs: update MVP_ROADMAP and TODO_LIST to reflect current project state

### DIFF
--- a/MVP_ROADMAP.md
+++ b/MVP_ROADMAP.md
@@ -6,11 +6,12 @@ by embedded developers as a minimal, dependency-free library.
 
 ---
 
-## Current State Summary (updated 2026-03-15)
+## Current State Summary (updated 2026-03-17)
 
-**MVP is complete and post-MVP work is ongoing.** All 190 tests pass. The build
+**MVP is complete and post-MVP work is ongoing.** All 191 tests pass. The build
 is clean (zero warnings, zero errors). The library has zero stdlib dependencies
-in `ok_json.c`. The CI Valgrind path is correct.
+in `ok_json.c`. The CI Valgrind path is correct. All cppcheck MISRA C:2012
+analysis checks pass with no suppressed rule exceptions.
 
 Post-MVP additions since the original MVP completion:
 - RFC 8259 number exponent notation (`1e10`, `2.5E-3`)
@@ -29,9 +30,19 @@ Post-MVP additions since the original MVP completion:
   2-, 3-, and 4-byte sequences; rejects overlong encodings, surrogates, and
   truncated sequences; invoked from the string scanner in `okj_parse_value()`
 - `okj_debug_print()` utility function for token-by-token parser state dump
-- MISRA C:2012 compliance work: `MISRA_C2012_COMPLIANCE.md` created; all
-  cppcheck-checked rules pass except five suppressed (Rules 8.9, 15.4, 15.5,
-  19.1, 19.2); project is substantially aligned with MISRA C:2012
+- `OkjParseContext` enum for grammar context tracking: detects structural errors
+  (trailing commas, missing colons, non-string object keys) during parsing
+- All getter functions refactored to output-parameter pattern: callers supply
+  a pointer to the result struct; no struct-by-value returns
+- All getter key parameters require an explicit `uint16_t key_len` argument;
+  no implicit `strlen()` calls inside the library
+- Single-return rule (MISRA Rule 15.5) applied to `okj_parse_value()` and all
+  getter functions; final-else added to all `if...else if` chains (Rule 15.4)
+- All previously suppressed MISRA C:2012 rules resolved: Rules 8.9, 15.4,
+  15.5, 19.1, 19.2; all cppcheck MISRA checks now pass with no suppressions
+- 100% branch coverage confirmed via gcov/gcovr (okj_debug_print excluded)
+- MISRA C:2012 compliance work: `MISRA_C2012_COMPLIANCE.md` created and updated;
+  all cppcheck-checked rules pass with no known outstanding rule failures
 - Test file changed to `#include "../src/ok_json.c"` directly, giving full
   visibility into static helpers for accurate branch coverage (gcov/gcovr)
 - Security and robustness tests: backslash flood at/over limit, escape
@@ -39,7 +50,7 @@ Post-MVP additions since the original MVP completion:
   injection (bare tab/LF in string values), modified UTF-8 NULL byte,
   quoted-string structural-character spoofing, multi-byte UTF-8 boundary
   cases, and many more
-- Test suite grown from 13 to 190 tests
+- Test suite grown from 13 to 191 tests
 
 The sections below are preserved for historical reference, with status
 annotations added. Open items have been moved to the TODO_LIST.
@@ -106,25 +117,25 @@ Resolved via Option A: test now asserts `token_count == 3` with tokens
 | 10 | Replace `isdigit()` with a range check | ✅ Done (`okj_is_digit`) |
 | 11 | Replace `strncmp()` for boolean/null detection with `okj_match()` | ✅ Done |
 | 12 | Remove `#include <ctype.h>` and `#include <string.h>` | ✅ Done |
-| 13 | Refactor `okj_parse()` to single-return (MISRA) | ✅ Done for `okj_parse()`; `okj_parse_value()` retains multiple early-returns (NULL guard + depth-stack errors) — see TODO_LIST |
+| 13 | Refactor `okj_parse()` to single-return (MISRA) | ✅ Done for `okj_parse()` and `okj_parse_value()` (post-MVP); all getter functions also refactored to single-return |
 
 ### Phase 3 — Implement getter functions ✅ COMPLETE
 
 | # | Function | Status |
 |---|----------|--------|
-| 14 | `okj_get_token()` | ✅ Implemented |
-| 15 | `okj_get_string()` | ✅ Implemented |
-| 16 | `okj_get_number()` | ✅ Implemented |
-| 17 | `okj_get_boolean()` | ✅ Implemented |
-| 18 | `okj_get_array()` | ✅ Implemented (count field now populated — done post-MVP) |
-| 19 | `okj_get_object()` | ✅ Implemented (count field now populated — done post-MVP) |
+| 14 | `okj_get_token(parser, key, key_len, out_tok)` | ✅ Implemented (output-parameter signature — post-MVP) |
+| 15 | `okj_get_string(parser, key, key_len, out_str)` | ✅ Implemented (output-parameter signature — post-MVP) |
+| 16 | `okj_get_number(parser, key, key_len, out_num)` | ✅ Implemented (output-parameter signature — post-MVP) |
+| 17 | `okj_get_boolean(parser, key, key_len, out_bool)` | ✅ Implemented (output-parameter signature — post-MVP) |
+| 18 | `okj_get_array(parser, key, key_len, out_arr)` | ✅ Implemented (count field + output-parameter signature — post-MVP) |
+| 19 | `okj_get_object(parser, key, key_len, out_obj)` | ✅ Implemented (count field + output-parameter signature — post-MVP) |
 
 ### Phase 4 — Test suite and CI ✅ COMPLETE
 
 | # | Task | Status |
 |---|------|--------|
 | 20 | Fix CI Valgrind path: `./tests/` → `./test/` in `ci.yml` | ✅ Already correct |
-| 21 | Add tests for each getter function once implemented | ✅ Done (190 tests total) |
+| 21 | Add tests for each getter function once implemented | ✅ Done (191 tests total) |
 | 22 | Add test for `OKJ_ERROR_MAX_TOKENS_EXCEEDED` | ✅ `test_max_tokens_exceeded` |
 | 23 | Add test for deeply nested JSON rejection | ✅ `test_deeply_nested_at_limit` (updated post-MVP to exercise depth ceiling) |
 | 24 | Add test for `OKJ_ERROR_UNEXPECTED_END` (truncated JSON) | ✅ `test_truncated_string` |
@@ -136,15 +147,17 @@ Resolved via Option A: test now asserts `token_count == 3` with tokens
 | 25 | Update README: remove WIP warning once tests pass | ✅ Done |
 | 26 | Add a minimal usage example to README | ✅ Done |
 | 27 | Fill in `@brief` docs on getter declarations in `ok_json.h` | ✅ Done |
-| 28 | Resolve `OKJ_MAX_TOKENS` macro vs const inconsistency in header | ✅ Resolved — `OKJ_MAX_TOKENS` is a macro (required for array dimension); `OKJ_MAX_STRING_LEN`, `OKJ_MAX_ARRAY_SIZE`, `OKJ_MAX_OBJECT_SIZE` are `static const` |
+| 28 | Resolve `OKJ_MAX_TOKENS` macro vs const inconsistency in header | ✅ Resolved — all size limits (`OKJ_MAX_TOKENS`, `OKJ_MAX_DEPTH`, `OKJ_MAX_STRING_LEN`, `OKJ_MAX_ARRAY_SIZE`, `OKJ_MAX_OBJECT_SIZE`, `OKJ_MAX_JSON_LEN`) are preprocessor macros, required for array dimensions and MISRA scope compliance |
 
 ---
 
 ## Out of Scope for MVP (status updated)
 
-- **Full MISRA C2012 compliance** — still requires a MISRA-capable toolchain
-  and formal analysis.  `okj_parse_value()` still has multiple early-returns;
-  see TODO_LIST.
+- **Full MISRA C2012 compliance** — all cppcheck MISRA C:2012 checks now pass
+  with no suppressed rule exceptions.  Previously suppressed rules (8.9, 15.4,
+  15.5, 19.1, 19.2) have been resolved post-MVP.  Formal compliance still
+  requires additional process evidence (deviation records, tool configuration
+  control, manual review) beyond static-analysis output alone.
 - **Nested structure depth tracking** — ✅ Implemented post-MVP.  A fixed-size
   16-slot depth/state stack now lives in `OkJsonParser`; bracket matching and
   depth ceiling enforced during parsing.
@@ -161,7 +174,7 @@ Resolved via Option A: test now asserts `token_count == 3` with tokens
 ## Definition of Done (MVP) — ✅ ALL MET
 
 1. ✅ `make` completes with zero warnings and zero errors.
-2. ✅ `make test` runs and all tests pass (13 at MVP; 190 as of 2026-03-15).
+2. ✅ `make test` runs and all tests pass (13 at MVP; 191 as of 2026-03-17).
 3. ✅ The Valgrind step in CI references the correct binary path.
 4. ✅ No `printf` debug statements remain in `ok_json.c`.
 5. ✅ `ok_json.c` does not `#include <ctype.h>`, `<string.h>`, or `<stdio.h>`.

--- a/TODO_LIST
+++ b/TODO_LIST
@@ -1,40 +1,61 @@
 Items that I want/need to work on:
 
-MVP is complete as of 2026-03-05. All 190 tests pass. Zero stdlib dependencies.
+MVP is complete as of 2026-03-05. All 191 tests pass. Zero stdlib dependencies.
 See MVP_ROADMAP.md for the full historical task list with completion status.
 
 Post-MVP items remaining:
-
-* Apply MISRA C2012 single-return to okj_parse_value() (Rule 15.5).
-  The function still has multiple early returns: one for the NULL-pointer guard
-  (OKJ_ERROR_BAD_POINTER) and many more throughout the else-if chain
-  (OKJ_ERROR_SYNTAX, OKJ_ERROR_MAX_DEPTH_EXCEEDED, OKJ_ERROR_BRACKET_MISMATCH).
-  Requires restructuring so all error paths set a single result variable and
-  fall through to one return at the end — the same pattern used in okj_parse().
-  Rule 15.5 is currently suppressed in the cppcheck MISRA configuration.
-
-* Apply MISRA C2012 final-else to all if...else if chains (Rule 15.4).
-  Rule 15.4 requires that every if...else if chain ends with a terminating
-  else clause. Currently suppressed in the cppcheck MISRA configuration.
-  Affected chains are primarily in okj_parse_value() and okj_validate_utf8_sequence().
 
 * Remove OKJ_VALID_CHARS from ok_json.h or put it to use.
   The 96-element static const array is defined in the header but referenced
   nowhere in ok_json.c or the tests. As a static in a header it gets
   duplicated into every translation unit that includes the header, wasting
-  ROM. This also triggers MISRA Rule 8.9 (objects with single-function scope
-  should be defined at block scope). Intended to be used for string character
-  validation in the future. Rule 8.9 is currently suppressed.
-
-* Resolve MISRA Rule 19.1 (objects should not be assigned or copied to
-  overlapping objects). Currently suppressed. Requires review and refactoring
-  of any copy/assignment operations that may involve overlapping objects.
-
-* Resolve MISRA Rule 19.2 (the union keyword should not be used). Currently
-  suppressed. Requires a redesign or alternative representation that avoids
-  unions, if any are present.
+  ROM. Intended to be used for string character validation in the future.
 
 Completed post-MVP items:
+
+* [DONE] Refactor all getter functions to output-parameter pattern (2026-03-17).
+  All getters (okj_get_string, okj_get_number, okj_get_boolean, okj_get_array,
+  okj_get_object, okj_get_token, okj_get_array_raw, okj_get_object_raw) now
+  write results into caller-supplied output structs rather than returning them
+  by value. This eliminates all stack-allocated struct returns and aligns with
+  MISRA C:2012 output-parameter conventions.
+
+* [DONE] Require explicit length params for all string/key inputs (2026-03-17).
+  All getters that accept a key name now take an explicit uint16_t key_len
+  parameter alongside the key pointer. Callers must pass the exact byte count;
+  no implicit strlen() calls are made inside the library.
+
+* [DONE] Apply MISRA C2012 single-return to okj_parse_value() (Rule 15.5).
+  The function was refactored so all error paths set a single result variable
+  and fall through to one return at the end, matching the pattern used in
+  okj_parse(). Rule 15.5 suppression removed.
+
+* [DONE] Apply MISRA C2012 final-else to all if...else if chains (Rule 15.4).
+  All if...else if chains in okj_parse_value() and okj_validate_utf8_sequence()
+  now end with a terminating else clause. Rule 15.4 suppression removed.
+
+* [DONE] Resolve MISRA Rule 8.9 (block scope for objects with single-function scope).
+  All constants previously defined at file scope with single-function use were
+  moved to block scope. Rule 8.9 suppression removed.
+
+* [DONE] Resolve MISRA Rule 19.1 (overlapping storage in copy/assignment).
+  All copy and assignment operations were reviewed and refactored to eliminate
+  any potential overlapping-object issues. Rule 19.1 suppression removed.
+
+* [DONE] Resolve MISRA Rule 19.2 (union keyword should not be used).
+  Any use of union was eliminated or replaced with an alternative representation.
+  Rule 19.2 suppression removed.
+
+* [DONE] Add OkjParseContext grammar context tracking (2026-03-15).
+  New enum OkjParseContext tracks what the parser expects next (value, key,
+  colon, separator/close) so structural errors such as trailing commas, missing
+  colons, and non-string object keys are detected immediately during parsing.
+  OkJsonParser carries a context field; depth_stack entries now encode both
+  depth and expected next token.
+
+* [DONE] Achieve 100% branch coverage (2026-03-15).
+  gcov/gcovr analysis confirmed 100% branch coverage across ok_json.c. The
+  okj_debug_print() function is excluded from coverage measurement.
 
 * [DONE] Remove test/ok_json_test_runner.c (2026-03-15).
   The placeholder file (containing only "/* placeholder */") was deleted.
@@ -44,16 +65,14 @@ Completed post-MVP items:
 * [DONE] Add okj_validate_utf8_sequence() for full RFC 3629 UTF-8 validation
   (2026-03-15). Handles 2-, 3-, and 4-byte sequences; rejects overlong
   encodings (including the modified UTF-8 NUL 0xC0 0x80), surrogate code
-  points (U+D800–U+DFFF), and truncated sequences. Integrated into the string
+  points (U+D800-U+DFFF), and truncated sequences. Integrated into the string
   scanner in okj_parse_value(). Supporting helpers: okj_is_utf8_continuation(),
   okj_is_hex_digit().
 
 * [DONE] Create MISRA_C2012_COMPLIANCE.md (2026-03-15).
   Formal compliance tracking document based on cppcheck MISRA analysis results.
-  All checked rules pass except five currently suppressed (Rules 8.9, 15.4,
-  15.5, 19.1, 19.2). Project is described as "substantially aligned with
-  current MISRA C:2012 static-analysis checks, with five known suppressed rule
-  exceptions."
+  All checked rules now pass; no suppressed rule exceptions remain. Project
+  passes all current cppcheck MISRA C:2012 analysis checks.
 
 * [DONE] Change test compilation to include src/ok_json.c directly (2026-03-15).
   test/ok_json_tests.c now has #include "../src/ok_json.c" at the top, giving


### PR DESCRIPTION
- Bump date to 2026-03-17; test count 190 → 191
- Document getter refactor to output-parameter pattern with explicit key_len
- Document OkjParseContext grammar context tracking addition
- Mark all previously suppressed MISRA rules resolved (8.9, 15.4, 15.5, 19.1, 19.2)
- Document single-return rule applied to okj_parse_value() and all getters
- Document 100% branch coverage achievement
- Fix macro vs static const note for all OKJ_MAX_* constants
- Move completed MISRA/getter items from open to done in TODO_LIST

https://claude.ai/code/session_01UZyPWEqnNsHPrwTpomymfs