### PR TITLE
docs: record JSONTestSuite 283/283 compliance verification

### DIFF
--- a/MVP_ROADMAP.md
+++ b/MVP_ROADMAP.md
@@ -13,6 +13,8 @@ is clean (zero warnings, zero errors). The library has zero stdlib dependencies
 in `ok_json.c`. The CI Valgrind path is correct. All cppcheck MISRA C:2012
 analysis checks pass with no suppressed rule exceptions. A libFuzzer-based fuzz
 target runs in CI (clang + ASan + UBSan, 10 seconds) and passes cleanly.
+External compliance verification via the JSONTestSuite confirms 283/283 tests
+pass with full RFC 8259 compliance (report: `json_compliance_report.txt`).
 
 Post-MVP additions since the original MVP completion:
 - RFC 8259 number exponent notation (`1e10`, `2.5E-3`)
@@ -181,6 +183,8 @@ Resolved via Option A: test now asserts `token_count == 3` with tokens
 
 1. ✅ `make` completes with zero warnings and zero errors.
 2. ✅ `make test` runs and all tests pass (13 at MVP; 191 as of 2026-03-17).
+8. ✅ External JSONTestSuite compliance: 283/283 tests pass; fully RFC 8259
+      compliant per `json_compliance_report.txt` (2026-03-17).
 3. ✅ The Valgrind step in CI references the correct binary path.
 4. ✅ No `printf` debug statements remain in `ok_json.c`.
 5. ✅ `ok_json.c` does not `#include <ctype.h>`, `<string.h>`, or `<stdio.h>`.

--- a/TODO_LIST
+++ b/TODO_LIST
@@ -8,6 +8,14 @@ Post-MVP items remaining:
 
 Completed post-MVP items:
 
+* [DONE] Verify RFC 8259 compliance via JSONTestSuite (2026-03-17).
+  Ran the full JSONTestSuite against the parser. All 283/283 tests pass with
+  result "SUCCESS: Fully RFC 8259 Compliant!". The i_ (implementation-defined)
+  files that were rejected (invalid UTF-8, UTF-16, lone continuation bytes,
+  overlong sequences, BOM, 500-level nesting) reflect deliberate strict
+  behaviour consistent with the library's design. Report saved to
+  json_compliance_report.txt in the repository root.
+
 * [DONE] Add libFuzzer fuzz target and CI job (2026-03-17).
   test/fuzz_target.c feeds arbitrary byte arrays into okj_parse() via the
   LLVMFuzzerTestOneInput entry point, compiled with clang -fsanitize=fuzzer,


### PR DESCRIPTION
External compliance run via JSONTestSuite confirms all 283 tests pass with "SUCCESS: Fully RFC 8259 Compliant!". Updated MVP_ROADMAP.md Current State Summary and Definition of Done, and added a completed entry to TODO_LIST referencing json_compliance_report.txt.

https://claude.ai/code/session_015ct69RB78W29yCgRtQwCTz