### PR TITLE
Add end-of-buffer boundary to container scanning helpers

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -425,32 +425,33 @@ static uint8_t okj_is_value_terminator(char c)
  * ---------------------------------------------------------------------------*/
 
 /* Advance `p` past a JSON string (including both surrounding quotes).
- * `p` must point at the opening '"'.  Returns a pointer to the character
- * immediately following the closing '"', or to '\0' on unterminated input.
+ * `p` must point at the opening '"'.  `end` is one past the last valid byte
+ * of the buffer.  Returns a pointer to the character immediately following
+ * the closing '"', or to `end` on unterminated / truncated input.
  * Recognises backslash escapes so that \" inside a string does not
  * prematurely terminate the scan. */
-static const char *okj_skip_string(const char *p)
+static const char *okj_skip_string(const char *p, const char *end)
 {
     const char *scan = p;
 
     scan++;   /* skip opening '"' */
 
-    while ((*scan != '"') && (*scan != '\0'))
+    while ((scan < end) && (*scan != '"'))
     {
         if (*scan == '\\')
         {
             scan++;    /* skip the backslash */
 
-            if (*scan == '\0')
+            if (scan >= end)
             {
-                break;  /* truncated input: backslash at end of stream */
+                break;  /* truncated input: backslash at end of buffer */
             }
         }
 
         scan++;
     }
 
-    if (*scan == '"')
+    if ((scan < end) && (*scan == '"'))
     {
         scan++;    /* skip closing '"' */
     }
@@ -459,10 +460,11 @@ static const char *okj_skip_string(const char *p)
 }
 
 /* Count the number of elements in a JSON array whose text begins at `start`
- * (which must point to the '[' character).  Handles nested arrays and objects
- * correctly by tracking bracket depth, and skips string content to avoid
- * counting structural characters that appear inside quoted values. */
-static uint16_t okj_count_array_elements(const char *start)
+ * (which must point to the '[' character).  `end` is one past the last valid
+ * byte of the buffer.  Handles nested arrays and objects correctly by tracking
+ * bracket depth, and skips string content to avoid counting structural
+ * characters that appear inside quoted values. */
+static uint16_t okj_count_array_elements(const char *start, const char *end)
 {
     const char *p = start;
 
@@ -476,14 +478,14 @@ static uint16_t okj_count_array_elements(const char *start)
 
         uint8_t  seen  = 0U;    /* set when first non-whitespace element is found */
 
-        while ((*p != '\0') && (depth > 0U))
+        while ((p < end) && (depth > 0U))
         {
             char c = *p;
 
             if (c == '"')
             {
                 /* Skip string content so commas inside strings are not counted. */
-                p = okj_skip_string(p);
+                p = okj_skip_string(p, end);
 
                 if ((depth == 1U) && (seen == 0U))
                 {
@@ -533,9 +535,10 @@ static uint16_t okj_count_array_elements(const char *start)
 }
 
 /* Count the number of key-value members in a JSON object whose text begins
- * at `start` (which must point to the '{' character).  Each colon at depth 1
- * corresponds to exactly one member. */
-static uint16_t okj_count_object_members(const char *start)
+ * at `start` (which must point to the '{' character).  `end` is one past the
+ * last valid byte of the buffer.  Each colon at depth 1 corresponds to
+ * exactly one member. */
+static uint16_t okj_count_object_members(const char *start, const char *end)
 {
     const char *p = start;
 
@@ -547,14 +550,14 @@ static uint16_t okj_count_object_members(const char *start)
 
         uint16_t depth = 1U;
 
-        while ((*p != '\0') && (depth > 0U))
+        while ((p < end) && (depth > 0U))
         {
             char c = *p;
 
             if (c == '"')
             {
                 /* Skip string content so colons inside keys/values are ignored. */
-                p = okj_skip_string(p);
+                p = okj_skip_string(p, end);
             }
             else
             {
@@ -584,11 +587,12 @@ static uint16_t okj_count_object_members(const char *start)
 }
 
 /* Measure the full byte length of a JSON array or object starting at `start`
- * (which must point to '[' or '{').  Returns the count of bytes from the
- * opening bracket to the matching closing bracket, inclusive.  String content
- * is skipped so that structural characters inside quoted values are ignored.
+ * (which must point to '[' or '{').  `end` is one past the last valid byte of
+ * the buffer.  Returns the count of bytes from the opening bracket to the
+ * matching closing bracket, inclusive.  String content is skipped so that
+ * structural characters inside quoted values are ignored.
  * Returns 0 if `start` is NULL or does not begin with '[' or '{'. */
-static uint16_t okj_measure_container(const char *start)
+static uint16_t okj_measure_container(const char *start, const char *end)
 {
     const char *p = start;
 
@@ -598,7 +602,7 @@ static uint16_t okj_measure_container(const char *start)
     {
         uint16_t depth  = 0U;
 
-        while (*p != '\0')
+        while (p < end)
         {
             char c = *p;
 
@@ -609,13 +613,13 @@ static uint16_t okj_measure_container(const char *start)
                 /* Skip past the opening quote (already counted above). */
                 p++;
 
-                while ((*p != '\0') && (*p != '"'))
+                while ((p < end) && (*p != '"'))
                 {
                     if (*p == '\\')
                     {
                         p++;
 
-                        if (*p != '\0')
+                        if (p < end)
                         {
                             length++;
                             p++;
@@ -630,7 +634,7 @@ static uint16_t okj_measure_container(const char *start)
                 }
 
                 /* Count the closing quote if present, then continue. */
-                if (*p == '"')
+                if ((p < end) && (*p == '"'))
                 {
                     length++;
                     p++;
@@ -1759,9 +1763,11 @@ OkjError okj_get_array(OkJsonParser *parser, const char *key, uint16_t key_len, 
         }
         else
         {
+            const char *end = parser->json + parser->json_len;
+
             out_arr->start  = parser->tokens[idx].start;
-            out_arr->count  = okj_count_array_elements(parser->tokens[idx].start);
-            out_arr->length = okj_measure_container(parser->tokens[idx].start);
+            out_arr->count  = okj_count_array_elements(parser->tokens[idx].start, end);
+            out_arr->length = okj_measure_container(parser->tokens[idx].start, end);
 
             if (out_arr->count > OKJ_MAX_ARRAY_SIZE)
             {
@@ -1791,9 +1797,11 @@ OkjError okj_get_object(OkJsonParser *parser, const char *key, uint16_t key_len,
         }
         else
         {
+            const char *end = parser->json + parser->json_len;
+
             out_obj->start  = parser->tokens[idx].start;
-            out_obj->count  = okj_count_object_members(parser->tokens[idx].start);
-            out_obj->length = okj_measure_container(parser->tokens[idx].start);
+            out_obj->count  = okj_count_object_members(parser->tokens[idx].start, end);
+            out_obj->length = okj_measure_container(parser->tokens[idx].start, end);
 
             if (out_obj->count > OKJ_MAX_OBJECT_SIZE)
             {
@@ -1880,9 +1888,11 @@ OkjError okj_get_array_raw(OkJsonParser *parser, const char *key, uint16_t key_l
         }
         else
         {
+            const char *end = parser->json + parser->json_len;
+
             out_arr->start  = parser->tokens[idx].start;
-            out_arr->count  = okj_count_array_elements(parser->tokens[idx].start);
-            out_arr->length = okj_measure_container(parser->tokens[idx].start);
+            out_arr->count  = okj_count_array_elements(parser->tokens[idx].start, end);
+            out_arr->length = okj_measure_container(parser->tokens[idx].start, end);
         }
     }
 
@@ -1907,9 +1917,11 @@ OkjError okj_get_object_raw(OkJsonParser *parser, const char *key, uint16_t key_
         }
         else
         {
+            const char *end = parser->json + parser->json_len;
+
             out_obj->start  = parser->tokens[idx].start;
-            out_obj->count  = okj_count_object_members(parser->tokens[idx].start);
-            out_obj->length = okj_measure_container(parser->tokens[idx].start);
+            out_obj->count  = okj_count_object_members(parser->tokens[idx].start, end);
+            out_obj->length = okj_measure_container(parser->tokens[idx].start, end);
         }
     }
 
@@ -2176,7 +2188,7 @@ void okj_debug_print(OkJsonParser *parser)
 
                 if ((t->type == OKJ_OBJECT) || (t->type == OKJ_ARRAY))
                 {
-                    dlen = okj_measure_container(t->start);
+                    dlen = okj_measure_container(t->start, parser->json + parser->json_len);
                 }
 
                 (void)printf("[%3u] type=%-9s len=%3u  val='",

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -4361,8 +4361,10 @@ void test_static_count_array_null_guard(void)
     /* okj_count_array_elements() returns 0 when passed NULL or a pointer
      * that does not begin with '['.  Direct call now that ok_json.c is
      * included as a single translation unit. */
-    assert(okj_count_array_elements(NULL) == 0U);
-    assert(okj_count_array_elements("not-an-array") == 0U);
+    char not_arr[] = "not-an-array";
+
+    assert(okj_count_array_elements(NULL, NULL) == 0U);
+    assert(okj_count_array_elements(not_arr, not_arr + (sizeof(not_arr) - 1U)) == 0U);
 
     printf("test_static_count_array_null_guard passed!\n");
 }
@@ -4371,8 +4373,10 @@ void test_static_count_object_null_guard(void)
 {
     /* okj_count_object_members() returns 0 when passed NULL or a pointer
      * that does not begin with '{'. */
-    assert(okj_count_object_members(NULL) == 0U);
-    assert(okj_count_object_members("not-an-object") == 0U);
+    char not_obj[] = "not-an-object";
+
+    assert(okj_count_object_members(NULL, NULL) == 0U);
+    assert(okj_count_object_members(not_obj, not_obj + (sizeof(not_obj) - 1U)) == 0U);
 
     printf("test_static_count_object_null_guard passed!\n");
 }
@@ -4381,8 +4385,10 @@ void test_static_measure_container_null_guard(void)
 {
     /* okj_measure_container() returns 0 when passed NULL or a pointer that
      * does not begin with '[' or '{'. */
-    assert(okj_measure_container(NULL) == 0U);
-    assert(okj_measure_container("not-a-container") == 0U);
+    char not_cont[] = "not-a-container";
+
+    assert(okj_measure_container(NULL, NULL) == 0U);
+    assert(okj_measure_container(not_cont, not_cont + (sizeof(not_cont) - 1U)) == 0U);
 
     printf("test_static_measure_container_null_guard passed!\n");
 }
@@ -4780,16 +4786,16 @@ void test_skip_string_backslash_escape(void)
 {
     /* okj_skip_string() is a static function visible because ok_json.c is
      * included directly.  Feed it a quoted string that contains a backslash
-     * escape sequence (e.g. \n) so that the backslash-skip branch at line 234
-     * is taken and the NUL check at line 236 evaluates to false. */
+     * escape sequence (e.g. \n) so that the backslash-skip branch is taken
+     * and the end-of-buffer check evaluates to false. */
 
     /* Raw bytes: " \ n " NUL  →  \"\\n\" in C notation */
     char s[] = "\"\\n\"";
 
-    const char *end = okj_skip_string(s);
+    const char *result = okj_skip_string(s, s + (sizeof(s) - 1U));
 
     /* Should advance past both characters of the escape and the closing quote */
-    assert(*end == '\0');
+    assert(*result == '\0');
 
     printf("test_skip_string_backslash_escape passed!\n");
 }
@@ -4797,16 +4803,16 @@ void test_skip_string_backslash_escape(void)
 void test_skip_string_backslash_at_eof(void)
 {
     /* Feed okj_skip_string() a string that ends with a lone backslash
-     * (no following escape character).  The NUL check at line 236 must
-     * evaluate to true and trigger the break at line 238.
+     * (no following escape character).  The end-of-buffer check must
+     * trigger the break when the scan reaches the buffer boundary.
      *
      * Raw bytes: "  a  \  NUL  — the string is never closed. */
     char s[] = {'"', 'a', '\\', '\0'};
 
-    const char *end = okj_skip_string(s);
+    const char *result = okj_skip_string(s, s + (sizeof(s) - 1U));
 
-    /* Scan stops at the NUL after the lone backslash */
-    assert(*end == '\0');
+    /* Scan stops at the buffer boundary; the byte there is the NUL */
+    assert(*result == '\0');
 
     printf("test_skip_string_backslash_at_eof passed!\n");
 }
@@ -4822,7 +4828,7 @@ void test_measure_container_escape_in_string(void)
      * Length: 8 characters inclusive of brackets. */
     char s[] = "[\"a\\nb\"]";
 
-    uint16_t len = okj_measure_container(s);
+    uint16_t len = okj_measure_container(s, s + (sizeof(s) - 1U));
 
     assert(len == 8U);
 
@@ -4839,8 +4845,8 @@ void test_measure_container_escape_at_eof(void)
     char s[] = {'[', '"', 'a', '\\', '\0'};
 
     /* The function must not crash; it returns whatever it measured before
-     * hitting NUL (the while loop exits because *p == '\0'). */
-    uint16_t len = okj_measure_container(s);
+     * hitting the buffer boundary (the while loop exits because p >= end). */
+    uint16_t len = okj_measure_container(s, s + (sizeof(s) - 1U));
 
     /* At minimum the opening '[' was counted (length >= 1). */
     assert(len >= 1U);


### PR DESCRIPTION
okj_skip_string, okj_count_array_elements, okj_count_object_members, and okj_measure_container previously scanned forward relying solely on a '\0' sentinel, which could read past the parser's json_len boundary.

Each function now accepts a `const char *end` parameter (one past the last valid byte).  All `*p != '\0'` / `*scan != '\0'` loop guards and the backslash-at-EOF checks are replaced with `p < end` / `scan < end` comparisons so the scan is bounded by the same region the main parser uses.

Callers (okj_get_array, okj_get_object, okj_get_array_raw, okj_get_object_raw, okj_debug_print) now derive `end` from `parser->json + parser->json_len` and pass it through.  Unit tests that call the static helpers directly are updated to compute `end` from the test buffer's known size.

https://claude.ai/code/session_01UNfWZ9r6cQRmMMqh9xasLX