### PR TITLE
docs: update README and wiki API reference to reflect current functio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ if (okj_get_boolean(&parser, "valid", 5U, &valid) == OKJ_SUCCESS) {
 /* 4. Copy a string value into a caller-supplied buffer */
 char buf[32];
 if (okj_get_string(&parser, "unit", 4U, &unit) == OKJ_SUCCESS) {
-    okj_copy_string(&unit, buf, sizeof(buf)); /* buf == "C\0" */
+    okj_copy_string(&unit, buf, (uint16_t)sizeof(buf)); /* buf == "C\0" */
 }
 ```
 
@@ -77,27 +77,27 @@ All getter functions return an `OkjError` code and write their result into a cal
 
 ### Value Getters
 
-Each getter writes its result into a caller-supplied struct and returns an `OkjError` code.
+Each getter returns `OkjError` and writes its result into a caller-supplied output struct.  All getters return `OKJ_ERROR_BAD_POINTER` when any pointer argument is `NULL`.
 
-| Function | Out-param type | Notes |
-|----------|---------------|-------|
-| `okj_get_string(parser, key, key_len, out_str)` | `OkJsonString *` | quotes excluded |
-| `okj_get_number(parser, key, key_len, out_num)` | `OkJsonNumber *` | raw numeric text |
-| `okj_get_boolean(parser, key, key_len, out_bool)` | `OkJsonBoolean *` | `"true"` or `"false"` literal |
-| `okj_get_array(parser, key, key_len, out_arr)` | `OkJsonArray *` | enforces `OKJ_MAX_ARRAY_SIZE` |
-| `okj_get_object(parser, key, key_len, out_obj)` | `OkJsonObject *` | enforces `OKJ_MAX_OBJECT_SIZE` |
-| `okj_get_array_raw(parser, key, key_len, out_arr)` | `OkJsonArray *` | full raw array text, no size limit |
-| `okj_get_object_raw(parser, key, key_len, out_obj)` | `OkJsonObject *` | full raw object text, no size limit |
-| `okj_get_token(parser, key, key_len, out_tok)` | `OkJsonToken *` | raw token from the parser's token array |
+| Function | Output struct | On success | On failure (non-NULL args) |
+|----------|--------------|------------|---------------------------|
+| `okj_get_string(parser, key, key_len, out_str)` | `OkJsonString *` | `OKJ_SUCCESS`; content excludes surrounding quotes | `OKJ_ERROR_BAD_STRING` — key not found or value is not a string |
+| `okj_get_number(parser, key, key_len, out_num)` | `OkJsonNumber *` | `OKJ_SUCCESS`; raw numeric text | `OKJ_ERROR_BAD_NUMBER` — key not found or value is not a number |
+| `okj_get_boolean(parser, key, key_len, out_bool)` | `OkJsonBoolean *` | `OKJ_SUCCESS`; `"true"` or `"false"` literal | `OKJ_ERROR_BAD_BOOLEAN` — key not found or value is not a boolean |
+| `okj_get_array(parser, key, key_len, out_arr)` | `OkJsonArray *` | `OKJ_SUCCESS`; enforces `OKJ_MAX_ARRAY_SIZE` | `OKJ_ERROR_BAD_ARRAY` — key not found, not an array, or element count exceeds `OKJ_MAX_ARRAY_SIZE` |
+| `okj_get_object(parser, key, key_len, out_obj)` | `OkJsonObject *` | `OKJ_SUCCESS`; enforces `OKJ_MAX_OBJECT_SIZE` | `OKJ_ERROR_BAD_OBJECT` — key not found, not an object, or member count exceeds `OKJ_MAX_OBJECT_SIZE` |
+| `okj_get_array_raw(parser, key, key_len, out_arr)` | `OkJsonArray *` | `OKJ_SUCCESS`; full raw array span, no size limit | `OKJ_ERROR_BAD_ARRAY` — key not found or value is not an array |
+| `okj_get_object_raw(parser, key, key_len, out_obj)` | `OkJsonObject *` | `OKJ_SUCCESS`; full raw object span, no size limit | `OKJ_ERROR_BAD_OBJECT` — key not found or value is not an object |
+| `okj_get_token(parser, key, key_len, out_tok)` | `OkJsonToken *` | `OKJ_SUCCESS`; raw token copied from parser token array | `OKJ_ERROR_BAD_POINTER` — key not found (no type-specific code) |
 
 ### Utilities
 
-| Function | Description |
-|----------|-------------|
-| `okj_copy_string(str, buf, buf_size)` | Copy string content into a caller buffer with NUL termination |
-| `okj_count_objects(parser)` | Count all `OKJ_OBJECT` tokens in the parsed result |
-| `okj_count_arrays(parser)` | Count all `OKJ_ARRAY` tokens in the parsed result |
-| `okj_count_elements(parser)` | Return the total token count (`parser->token_count`) |
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `okj_copy_string(str, buf, buf_size)` | `uint16_t` | Copy string content into a caller-supplied buffer with NUL termination; returns bytes copied (excluding NUL), or `0` on error |
+| `okj_count_objects(parser)` | `uint16_t` | Count all `OKJ_OBJECT` tokens in the parsed result, including nested objects; returns `0` if `parser` is `NULL` |
+| `okj_count_arrays(parser)` | `uint16_t` | Count all `OKJ_ARRAY` tokens in the parsed result, including nested arrays; returns `0` if `parser` is `NULL` |
+| `okj_count_elements(parser)` | `uint16_t` | Return the total token count (equivalent to `parser->token_count`); returns `0` if `parser` is `NULL` |
 
 ### Debug (compile with `-DOK_JSON_DEBUG`)
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -110,12 +110,33 @@ pointers retrieved from the parser.
 Tokenizes the bound JSON text and returns a status code.  On success,
 `parser->tokens` and `parser->token_count` are populated.
 
+Possible return codes:
+
+| Code | Condition |
+|------|-----------|
+| `OKJ_SUCCESS` | Parse completed; tokens are valid |
+| `OKJ_ERROR_BAD_POINTER` | `parser` is `NULL` |
+| `OKJ_ERROR_MAX_JSON_LEN_EXCEEDED` | `json_len` exceeds `OKJ_MAX_JSON_LEN` |
+| `OKJ_ERROR_SYNTAX` | Trailing non-whitespace after the top-level value |
+| `OKJ_ERROR_MAX_TOKENS_EXCEEDED` | Token array full before input was consumed |
+| `OKJ_ERROR_UNEXPECTED_END` | Unclosed containers or empty/whitespace-only input |
+| `OKJ_ERROR_INVALID_CHARACTER` | Unexpected character in the input stream |
+| `OKJ_ERROR_BAD_NUMBER` | Malformed numeric literal |
+| `OKJ_ERROR_BAD_STRING` | Malformed string literal |
+| `OKJ_ERROR_BAD_BOOLEAN` | Malformed boolean literal |
+| `OKJ_ERROR_BRACKET_MISMATCH` | Mismatched opening/closing bracket or brace |
+| `OKJ_ERROR_MAX_DEPTH_EXCEEDED` | Nesting depth exceeds `OKJ_MAX_DEPTH` |
+| `OKJ_ERROR_MAX_STR_LEN_EXCEEDED` | Key or string token exceeds `OKJ_MAX_STRING_LEN` |
+
 ## Key-based getters
 
 Each getter scans for an `OKJ_STRING` token whose content matches `key`, then
 writes the immediately following token into a caller-supplied output struct.
-All getters return `OkjError` — `OKJ_SUCCESS` on success, or the appropriate
-error code on a missing key, type mismatch, or bad argument.
+All getters return `OkjError` — `OKJ_SUCCESS` on success, or an error code on
+a missing key, type mismatch, or bad argument.  `key_len` is the byte length
+of the key string (excluding any null terminator).
+
+**All getters return `OKJ_ERROR_BAD_POINTER` when any pointer argument is `NULL`.**
 
 ```c
 OkjError okj_get_string (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonString  *out_str);
@@ -126,11 +147,27 @@ OkjError okj_get_object (OkJsonParser *parser, const char *key, uint16_t key_len
 OkjError okj_get_token  (OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonToken   *out_tok);
 ```
 
-`key_len` is the byte length of the key string (excluding any null terminator).
+### Per-getter return codes
 
-`okj_get_array` and `okj_get_object` enforce `OKJ_MAX_ARRAY_SIZE` and
-`OKJ_MAX_OBJECT_SIZE` respectively and return `OKJ_ERROR_BAD_ARRAY` /
-`OKJ_ERROR_BAD_OBJECT` when the container exceeds the limit.
+| Getter | Not-found or type-mismatch code |
+|--------|--------------------------------|
+| `okj_get_string` | `OKJ_ERROR_BAD_STRING` |
+| `okj_get_number` | `OKJ_ERROR_BAD_NUMBER` |
+| `okj_get_boolean` | `OKJ_ERROR_BAD_BOOLEAN` |
+| `okj_get_array` | `OKJ_ERROR_BAD_ARRAY` |
+| `okj_get_object` | `OKJ_ERROR_BAD_OBJECT` |
+| `okj_get_token` | `OKJ_ERROR_BAD_POINTER` (no type-specific code; any value type is accepted) |
+
+**`okj_get_token` note:** unlike the other getters, `okj_get_token` accepts any
+value type — it returns the raw token regardless of its `OkJsonType`.  When the
+key is not found, it returns `OKJ_ERROR_BAD_POINTER` (the same code used for
+NULL arguments), not a type-specific error.
+
+**`okj_get_array` and `okj_get_object` partial-write note:** when the element
+or member count exceeds `OKJ_MAX_ARRAY_SIZE` / `OKJ_MAX_OBJECT_SIZE`, the
+output struct fields (`start`, `count`, `length`) are still written before the
+limit check fires and `OKJ_ERROR_BAD_ARRAY` / `OKJ_ERROR_BAD_OBJECT` is
+returned.  Always check the return code before using the output struct.
 
 ### Raw container getters
 
@@ -141,7 +178,9 @@ OkjError okj_get_array_raw (OkJsonParser *parser, const char *key, uint16_t key_
 OkjError okj_get_object_raw(OkJsonParser *parser, const char *key, uint16_t key_len, OkJsonObject *out_obj);
 ```
 
-Use raw variants when you need the exact source span of a large container.
+Return codes mirror the non-raw variants (`OKJ_ERROR_BAD_ARRAY` /
+`OKJ_ERROR_BAD_OBJECT`) but without any size limit check.  Use raw variants
+when you need the exact source span of a large container.
 
 ### String copy helper
 


### PR DESCRIPTION
…n signatures and return codes

- README getter table: rename 'Out-param type' column to 'Output struct' and add explicit 'On success' / 'On failure' columns with the exact OkjError codes each getter returns (OKJ_ERROR_BAD_STRING, OKJ_ERROR_BAD_NUMBER, OKJ_ERROR_BAD_BOOLEAN, OKJ_ERROR_BAD_ARRAY, OKJ_ERROR_BAD_OBJECT, or OKJ_ERROR_BAD_POINTER for okj_get_token)
- README utilities table: add Returns column with uint16_t and document NULL-parser behaviour (returns 0) for all three counting helpers
- README Quick Start: fix okj_copy_string call to cast sizeof(buf) to uint16_t, matching the function signature
- wiki/API-Reference: expand okj_parse section with a full table of possible return codes
- wiki/API-Reference: add per-getter return-code table; call out that okj_get_token returns OKJ_ERROR_BAD_POINTER on not-found (unlike the type-specific codes used by the other getters); document the partial-write behaviour of okj_get_array / okj_get_object when the size limit is exceeded

https://claude.ai/code/session_01NJixwcioGAPgWwSgxCUWDx