### PR TITLE
Fix four Frama-C WP timeouts in okj_measure_container

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -704,19 +704,16 @@ static uint16_t okj_measure_container(const char *start, const char *end)
 
     const char *p = start;
 
-    uint16_t length = 0U;
-
     if ((p != NULL) && ((*p == '[') || (*p == '{')))
     {
-        uint16_t depth  = 0U;
+        uint16_t depth = 0U;
 
         /*@
           // OUTER LOOP INVARIANTS
           loop invariant \base_addr(p) == \base_addr(start);
           loop invariant start <= p <= end;
-          loop invariant length == p - start;
-          
-          loop assigns p, depth, length;
+
+          loop assigns p, depth;
           loop variant end - p;
         */
         while (p < end)
@@ -725,17 +722,15 @@ static uint16_t okj_measure_container(const char *start, const char *end)
 
             if (c == '"')
             {
-                /* Skip opening quote - strictly paired increments */
+                /* Skip opening quote */
                 p++;
-                length++;
 
                 /*@
                   // INNER LOOP INVARIANTS
                   loop invariant \base_addr(p) == \base_addr(start);
                   loop invariant start <= p <= end;
-                  loop invariant length == p - start;
-                  
-                  loop assigns p, length;
+
+                  loop assigns p;
                   loop variant end - p;
                 */
                 while ((p < end) && (*p != '"'))
@@ -743,26 +738,22 @@ static uint16_t okj_measure_container(const char *start, const char *end)
                     if (*p == '\\')
                     {
                         p++;
-                        length++;
 
                         if (p < end)
                         {
                             p++;
-                            length++;
                         }
                     }
                     else
                     {
                         p++;
-                        length++;
                     }
                 }
 
-                /* Count the closing quote if present */
+                /* Skip the closing quote if present */
                 if ((p < end) && (*p == '"'))
                 {
                     p++;
-                    length++;
                 }
             }
             else
@@ -776,9 +767,7 @@ static uint16_t okj_measure_container(const char *start, const char *end)
                     depth--;
                 }
 
-                /* Strictly paired increments */
                 p++;
-                length++;
 
                 if (depth == 0U)
                 {
@@ -788,7 +777,7 @@ static uint16_t okj_measure_container(const char *start, const char *end)
         }
     }
 
-    return length;
+    return (uint16_t)(p - start);
 }
 
 /*@


### PR DESCRIPTION
Remove the `length` variable from both loops and compute the return value as `(uint16_t)(p - start)` at the function exit.

The four timeouts all stemmed from the loop invariants `length == p - start` (invariants 3 and 6).  Alt-Ergo could not discharge these in time because `length` is `uint16_t` while `p - start` is `ptrdiff_t`; the solver had to reason about implicit type coercion and potential modular wrap-around at every step of the complex escape-handling branch.

By tracking only `p` in the loops and deferring the single cast to the return site the invariants reduce to the simple pointer-bounds facts `start <= p <= end`, which Qed/Alt-Ergo can handle instantly.

The postcondition `\result <= end - start` still holds because `uint16_t` truncation is monotone for non-negative values:
  (uint16_t)(p - start) <= p - start <= end - start.

https://claude.ai/code/session_01EJMoYdvmgosAD1Dj5PriBC