### PR TITLE
Fix Frama-C timeout on okj_measure_container loop variant

### DIFF
--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -718,6 +718,7 @@ static uint16_t okj_measure_container(const char *start, const char *end)
         */
         while (p < end)
         {
+            //@ ghost const char *p_entry = p;
             char c = *p;
 
             if (c == '"')
@@ -774,6 +775,8 @@ static uint16_t okj_measure_container(const char *start, const char *end)
                     break;
                 }
             }
+
+            //@ assert p > p_entry;
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes the last remaining Frama-C WP timeout (`typed_okj_measure_container_loop_variant_decrease`)
- Adds a ghost variable `p_entry` capturing `p` at the start of each outer loop iteration, plus an `assert p > p_entry` at the end, giving the prover a stepping stone to conclude the loop variant `end - p` strictly decreases
- Both branches (string-skipping and structural character) always advance `p` by at least 1, so the assertion is sound

## Test plan
- [ ] Run Frama-C WP and confirm 829/829 goals proved with no timeouts

https://claude.ai/code/session_01EQLnRiTToFU1T5KzMQDkjc