### PR TITLE
Fix heap-buffer-overread vulnerabilities from Issue #69

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,21 @@ jobs:
         run: |
           # Give the 'opam' user ownership of the checked-out workspace
           chown -R opam:opam .
-          
+
           echo "## ACSL Contract Verification Results" >> $GITHUB_STEP_SUMMARY
           echo '```text' >> $GITHUB_STEP_SUMMARY
-          
-          # Temporarily disable 'exit on error' so we can capture the output 
+
+          # Temporarily disable 'exit on error' so we can capture the output
           # safely even if the WP prover fails to prove a goal.
           set +e
-          
+
+          # Issue #69 note: okj_parse_value and okj_parse are NOT yet in this
+          # list.  They carry ACSL preconditions (see src/ok_json.c) but
+          # discharging their inner-loop WP goals requires additional loop
+          # invariants that are tracked as follow-up work.  The runtime OOB
+          # checks added for Issue #69 plus the heap-tight-buffer libFuzzer
+          # harness + ASan regression tests guard against the specific bugs
+          # in the interim.
           # Run Frama-C as the opam user and capture stdout/stderr into a variable
           OUTPUT=$(su opam -c 'opam exec -- frama-c \
             -cpp-extra-args="-I./include -std=c99" \

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -845,32 +845,33 @@ static void okj_skip_whitespace(OkJsonParser *parser)
 }
 
 /*@
-  // 1. Preconditions
+  // Preconditions
   //
   // parser may be NULL — we handle that gracefully by returning
-  // OKJ_ERROR_BAD_POINTER.  If non-NULL, the struct must be valid for r/w.
+  // OKJ_ERROR_BAD_POINTER.  If non-NULL, the struct must be valid for r/w
+  // and the json buffer it references must be readable for the full
+  // json_len bytes (otherwise every indexed read inside the inner loops
+  // is undefined behavior — the class of bug Issue #69 reported).
   requires parser == \null || \valid(parser);
-
-  // If parser is non-NULL, the json buffer it references must be readable
-  // for at least json_len bytes.  Without this, every indexed read inside
-  // this function's inner loops (strings, numbers, escapes, keywords) is
-  // undefined behavior — that is exactly the class of bug Issue #69 reported.
   requires parser != \null ==>
              \valid_read(parser->json + (0 .. parser->json_len - 1));
-
-  // position must be within or at the end of the buffer at entry.  Callers
-  // (okj_parse, recursive entry for containers) maintain this invariant.
   requires parser != \null ==> parser->position <= parser->json_len;
-
-  // Token array must be addressable.
   requires parser != \null ==>
              \valid(parser->tokens + (0 .. OKJ_MAX_TOKENS - 1));
 
-  // 2. Frame condition
-  assigns parser == \null ? \nothing : *parser;
+  // Behaviors carry the frame condition — ACSL does not support a ternary
+  // in the assigns clause, so we split the two cases into behaviors.
+  behavior null_parser:
+    assumes parser == \null;
+    assigns \nothing;
 
-  // 3. Postconditions
-  ensures parser != \null ==> parser->position <= parser->json_len;
+  behavior valid_parser:
+    assumes parser != \null;
+    assigns *parser;
+    ensures parser->position <= parser->json_len;
+
+  complete behaviors;
+  disjoint behaviors;
 
   // NOTE: Full WP verification of this function requires extensive loop
   // invariants on the string/number/escape inner loops.  This is tracked
@@ -1229,14 +1230,24 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                                 {
                                     bytes_need = 3U;
                                 }
-                                else if (lead_byte >= 0xC2U)
+                                else if (lead_byte >= 0x80U)
                                 {
+                                    /* Any byte > 0x7F causes okj_validate_utf8_sequence
+                                     * to unconditionally read src[pos + 1] at line 199
+                                     * BEFORE it classifies the lead byte.  That includes
+                                     * invalid lead bytes in the range 0x80..0xC1 (which
+                                     * the validator ultimately rejects — but only AFTER
+                                     * the continuation-byte read).  So we must ensure at
+                                     * least 2 bytes are available for every non-ASCII
+                                     * byte, not just valid 2-byte leads (>=0xC2).  Without
+                                     * this, input like {"":"&7\x80 (fuzzer-found) reaches
+                                     * the validator with only 1 byte left and triggers a
+                                     * heap-buffer-overread. */
                                     bytes_need = 2U;
                                 }
                                 else
                                 {
-                                    /* 1-byte ASCII or an invalid lead byte — the
-                                     * validator will handle these without OOB. */
+                                    /* ASCII: 1-byte path inside the validator. */
                                     bytes_need = 1U;
                                 }
 
@@ -1700,21 +1711,26 @@ void okj_init(OkJsonParser *parser, char *json_string, uint16_t json_len)
 }
 
 /*@
-  // 1. Preconditions
-  requires parser == \null || \valid(parser);
-
   // Same buffer-readability precondition as okj_parse_value: without it,
   // the subordinate reads inside the main dispatch are UB.  This is the
   // contract the public API documents to callers via okj_init's length
   // parameter.
+  requires parser == \null || \valid(parser);
   requires parser != \null ==>
              \valid_read(parser->json + (0 .. parser->json_len - 1));
-
   requires parser != \null ==>
              \valid(parser->tokens + (0 .. OKJ_MAX_TOKENS - 1));
 
-  // 2. Frame condition
-  assigns parser == \null ? \nothing : *parser;
+  behavior null_parser:
+    assumes parser == \null;
+    assigns \nothing;
+
+  behavior valid_parser:
+    assumes parser != \null;
+    assigns *parser;
+
+  complete behaviors;
+  disjoint behaviors;
 
   // NOTE: This function is not yet in the -wp-fct list because fully
   // discharging its WP goals requires loop invariants matching those in

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -844,6 +844,39 @@ static void okj_skip_whitespace(OkJsonParser *parser)
     }
 }
 
+/*@
+  // 1. Preconditions
+  //
+  // parser may be NULL — we handle that gracefully by returning
+  // OKJ_ERROR_BAD_POINTER.  If non-NULL, the struct must be valid for r/w.
+  requires parser == \null || \valid(parser);
+
+  // If parser is non-NULL, the json buffer it references must be readable
+  // for at least json_len bytes.  Without this, every indexed read inside
+  // this function's inner loops (strings, numbers, escapes, keywords) is
+  // undefined behavior — that is exactly the class of bug Issue #69 reported.
+  requires parser != \null ==>
+             \valid_read(parser->json + (0 .. parser->json_len - 1));
+
+  // position must be within or at the end of the buffer at entry.  Callers
+  // (okj_parse, recursive entry for containers) maintain this invariant.
+  requires parser != \null ==> parser->position <= parser->json_len;
+
+  // Token array must be addressable.
+  requires parser != \null ==>
+             \valid(parser->tokens + (0 .. OKJ_MAX_TOKENS - 1));
+
+  // 2. Frame condition
+  assigns parser == \null ? \nothing : *parser;
+
+  // 3. Postconditions
+  ensures parser != \null ==> parser->position <= parser->json_len;
+
+  // NOTE: Full WP verification of this function requires extensive loop
+  // invariants on the string/number/escape inner loops.  This is tracked
+  // as follow-up work (see TODO_LIST).  Adding this function to -wp-fct
+  // without those invariants will produce unverified goals.
+ */
 /*
  * TODO: Refactor to reduce complexity. -RLM
  */
@@ -1119,17 +1152,35 @@ static OkjError okj_parse_value(OkJsonParser *parser)
 
                                     uint16_t h;
 
+                                    /* RFC 8259 §7: \u escape MUST be followed by exactly 4
+                                     * hex digits.  Each digit read requires a bounds check —
+                                     * the outer while loop only guards entry into the string
+                                     * body, not individual reads inside this inner for loop.
+                                     * Without the check, truncated input such as
+                                     * {"a":"\uAB (10 bytes, no NUL terminator) causes a
+                                     * heap-buffer-overread past parser->json[parser->json_len-1].
+                                     *
+                                     * We also gate every iteration on loop_break so that once
+                                     * an error is detected, parser->position does not continue
+                                     * to advance past the error point. */
                                     for (h = 0U; h < 4U; h++)
                                     {
-                                        if ((okj_is_hex_digit(parser->json[parser->position]) == 0U) &&
-                                            (loop_break != 1U))
+                                        if (loop_break == 0U)
                                         {
-                                            result = OKJ_ERROR_BAD_STRING;
-                                            loop_break = 1U;
-                                        }
-                                        else
-                                        {
-                                            parser->position++;
+                                            if (parser->position >= parser->json_len)
+                                            {
+                                                result = OKJ_ERROR_BAD_STRING;
+                                                loop_break = 1U;
+                                            }
+                                            else if (okj_is_hex_digit(parser->json[parser->position]) == 0U)
+                                            {
+                                                result = OKJ_ERROR_BAD_STRING;
+                                                loop_break = 1U;
+                                            }
+                                            else
+                                            {
+                                                parser->position++;
+                                            }
                                         }
                                     }
                                 }
@@ -1158,7 +1209,43 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                             }
                             else
                             {
-                                if (okj_validate_utf8_sequence(parser->json,
+                                /* okj_validate_utf8_sequence's ACSL contract requires
+                                 * \valid_read(src + (pos .. pos + 3)) — 4 readable bytes.
+                                 * The outer while loop only guarantees 1 byte
+                                 * (parser->position < parser->json_len), so we must
+                                 * verify the remaining bytes match what the lead byte
+                                 * demands before calling.  Otherwise, truncated input
+                                 * like {"a":"\xC2 (7 bytes, no NUL) causes a heap-
+                                 * buffer-overread at src[pos+1]. */
+                                uint8_t  lead_byte   = (uint8_t)parser->json[parser->position];
+                                uint16_t bytes_need  = 1U;
+                                uint16_t bytes_avail = (uint16_t)(parser->json_len - parser->position);
+
+                                if (lead_byte >= 0xF0U)
+                                {
+                                    bytes_need = 4U;
+                                }
+                                else if (lead_byte >= 0xE0U)
+                                {
+                                    bytes_need = 3U;
+                                }
+                                else if (lead_byte >= 0xC2U)
+                                {
+                                    bytes_need = 2U;
+                                }
+                                else
+                                {
+                                    /* 1-byte ASCII or an invalid lead byte — the
+                                     * validator will handle these without OOB. */
+                                    bytes_need = 1U;
+                                }
+
+                                if (bytes_avail < bytes_need)
+                                {
+                                    result = OKJ_ERROR_BAD_STRING;
+                                    loop_break = 1U;
+                                }
+                                else if (okj_validate_utf8_sequence(parser->json,
                                                             parser->position,
                                                             &utf8_advance) == 0U)
                                 {
@@ -1344,7 +1431,8 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                 }
             }
         }
-        else if (okj_match(&parser->json[parser->position], "true", 4U) == 1U)
+        else if (((uint16_t)(parser->json_len - parser->position) >= 4U) &&
+                 (okj_match(&parser->json[parser->position], "true", 4U) == 1U))
         {
             /* Keyword literals are only valid in value positions. */
             if ((parser->context != OKJ_CTX_WANT_VALUE) &&
@@ -1379,7 +1467,8 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                 }
             }
         }
-        else if (okj_match(&parser->json[parser->position], "false", 5U) == 1U)
+        else if (((uint16_t)(parser->json_len - parser->position) >= 5U) &&
+                 (okj_match(&parser->json[parser->position], "false", 5U) == 1U))
         {
             if ((parser->context != OKJ_CTX_WANT_VALUE) &&
                 (parser->context != OKJ_CTX_WANT_VALUE_OR_CLOSE))
@@ -1411,7 +1500,8 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                 }
             }
         }
-        else if (okj_match(&parser->json[parser->position], "null", 4U) == 1U)
+        else if (((uint16_t)(parser->json_len - parser->position) >= 4U) &&
+                 (okj_match(&parser->json[parser->position], "null", 4U) == 1U))
         {
             if ((parser->context != OKJ_CTX_WANT_VALUE) &&
                 (parser->context != OKJ_CTX_WANT_VALUE_OR_CLOSE))
@@ -1609,6 +1699,29 @@ void okj_init(OkJsonParser *parser, char *json_string, uint16_t json_len)
     }
 }
 
+/*@
+  // 1. Preconditions
+  requires parser == \null || \valid(parser);
+
+  // Same buffer-readability precondition as okj_parse_value: without it,
+  // the subordinate reads inside the main dispatch are UB.  This is the
+  // contract the public API documents to callers via okj_init's length
+  // parameter.
+  requires parser != \null ==>
+             \valid_read(parser->json + (0 .. parser->json_len - 1));
+
+  requires parser != \null ==>
+             \valid(parser->tokens + (0 .. OKJ_MAX_TOKENS - 1));
+
+  // 2. Frame condition
+  assigns parser == \null ? \nothing : *parser;
+
+  // NOTE: This function is not yet in the -wp-fct list because fully
+  // discharging its WP goals requires loop invariants matching those in
+  // okj_parse_value.  Issue #69's OOB reads are prevented at the source
+  // level (inside okj_parse_value) and guarded by ASan-instrumented
+  // regression tests + the updated libFuzzer harness.
+ */
 OkjError okj_parse(OkJsonParser *parser)
 {
     OkjError result = OKJ_SUCCESS;

--- a/src/ok_json.c
+++ b/src/ok_json.c
@@ -146,53 +146,66 @@ static uint8_t okj_is_utf8_continuation(uint8_t byte)
 }
 
 /*@
-  // 1. Preconditions
+  // Preconditions
   requires src != \null;
   requires advance != \null;
-  
-  // The caller MUST guarantee that the advance pointer is writable.
   requires \valid(advance);
-  
-  // The caller MUST guarantee that it is safe to read up to 4 bytes 
-  // starting at the current position. If they pass a string that ends 
-  // 2 bytes from 'pos', Frama-C will fail the build at the call site!
-  // We also ensure pos doesn't mathematically overflow when adding 3.
-  requires pos <= 65531; 
-  requires \valid_read(src + (pos .. pos + 3));
 
-  // 2. Frame Condition
-  // We only modify the value pointed to by 'advance'
+  // The full buffer is readable for at least `len` bytes.  Unlike the
+  // previous contract which required 4 readable bytes starting at `pos`,
+  // this version makes the validator self-defensive: it inspects `len`
+  // internally and refuses to read past it.  Issue #69 and the follow-up
+  // libFuzzer finds both traced to callers that could not reliably
+  // establish the old "4 readable bytes" precondition for arbitrary input.
+  requires pos < len;
+  requires \valid_read(src + (0 .. len - 1));
+
+  // Frame condition
   assigns *advance;
 
-  // 3. Behaviors
+  // Behaviors
   behavior success:
     assumes src != \null && advance != \null;
-    // The function must return a boolean 0 or 1
     ensures \result == 0 || \result == 1;
-    // If it succeeds, the advance pointer must be set between 1 and 4
     ensures \result == 1 ==> (*advance >= 1 && *advance <= 4);
 
   complete behaviors;
   disjoint behaviors;
 */
-static uint8_t okj_validate_utf8_sequence(const char *src, uint16_t pos, uint16_t *advance)
+static uint8_t okj_validate_utf8_sequence(const char *src,
+                                          uint16_t    pos,
+                                          uint16_t    len,
+                                          uint16_t   *advance)
 {
-    /* Validate one UTF-8 scalar-value sequence starting at src[pos].
-     * On success sets *advance (1..4) and returns 1, else returns 0.
+    /* Validate one UTF-8 scalar-value sequence starting at src[pos], with
+     * `len` being the total length of `src`.  On success sets *advance
+     * (1..4) and returns 1; on invalid/truncated input returns 0 without
+     * reading past src[len - 1].
+     *
+     * Every multi-byte read is gated by an explicit bounds check against
+     * `len` so that truncated input (a multi-byte lead at end-of-buffer)
+     * is rejected as invalid, not a heap-buffer-overread.
+     *
      * TODO: Refactoring this to comply with single return rule has
      * really made the cognitive complexity of this function worse.
      * Need to refactor this again to reduce it. -RLM
      */
     uint8_t result = 0U;
 
-    if ((src != NULL) && (advance != NULL))
+    if ((src != NULL) && (advance != NULL) && (pos < len))
     {
-        uint8_t b0 = (uint8_t)src[pos];
+        uint8_t  b0         = (uint8_t)src[pos];
+        uint16_t bytes_left = (uint16_t)(len - pos);
 
         if (b0 <= 0x7FU)
         {
             *advance = 1U;
             result = 1U;
+        }
+        else if (bytes_left < 2U)
+        {
+            /* Need b1 but no byte after the lead is available — truncated. */
+            result = 0U;
         }
         else
         {
@@ -209,6 +222,14 @@ static uint8_t okj_validate_utf8_sequence(const char *src, uint16_t pos, uint16_
                 {
                     result = 0U;
                 }
+            }
+            else if (bytes_left < 3U)
+            {
+                /* Need b2 but fewer than 3 bytes available — truncated or
+                 * the lead byte is in an invalid range (e.g. 0x80..0xC1)
+                 * that the validator can only classify as "not a 2-byte
+                 * sequence" after reading b2. */
+                result = 0U;
             }
             else
             {
@@ -257,6 +278,12 @@ static uint8_t okj_validate_utf8_sequence(const char *src, uint16_t pos, uint16_
                             {
                                 result = 0U;
                             }
+                        }
+                        else if (bytes_left < 4U)
+                        {
+                            /* Need b3 for 4-byte paths (or to reject invalid
+                             * lead bytes in 0x80..0xC1 / 0xF5..0xFF). */
+                            result = 0U;
                         }
                         else
                         {
@@ -1210,54 +1237,16 @@ static OkjError okj_parse_value(OkJsonParser *parser)
                             }
                             else
                             {
-                                /* okj_validate_utf8_sequence's ACSL contract requires
-                                 * \valid_read(src + (pos .. pos + 3)) — 4 readable bytes.
-                                 * The outer while loop only guarantees 1 byte
-                                 * (parser->position < parser->json_len), so we must
-                                 * verify the remaining bytes match what the lead byte
-                                 * demands before calling.  Otherwise, truncated input
-                                 * like {"a":"\xC2 (7 bytes, no NUL) causes a heap-
-                                 * buffer-overread at src[pos+1]. */
-                                uint8_t  lead_byte   = (uint8_t)parser->json[parser->position];
-                                uint16_t bytes_need  = 1U;
-                                uint16_t bytes_avail = (uint16_t)(parser->json_len - parser->position);
-
-                                if (lead_byte >= 0xF0U)
-                                {
-                                    bytes_need = 4U;
-                                }
-                                else if (lead_byte >= 0xE0U)
-                                {
-                                    bytes_need = 3U;
-                                }
-                                else if (lead_byte >= 0x80U)
-                                {
-                                    /* Any byte > 0x7F causes okj_validate_utf8_sequence
-                                     * to unconditionally read src[pos + 1] at line 199
-                                     * BEFORE it classifies the lead byte.  That includes
-                                     * invalid lead bytes in the range 0x80..0xC1 (which
-                                     * the validator ultimately rejects — but only AFTER
-                                     * the continuation-byte read).  So we must ensure at
-                                     * least 2 bytes are available for every non-ASCII
-                                     * byte, not just valid 2-byte leads (>=0xC2).  Without
-                                     * this, input like {"":"&7\x80 (fuzzer-found) reaches
-                                     * the validator with only 1 byte left and triggers a
-                                     * heap-buffer-overread. */
-                                    bytes_need = 2U;
-                                }
-                                else
-                                {
-                                    /* ASCII: 1-byte path inside the validator. */
-                                    bytes_need = 1U;
-                                }
-
-                                if (bytes_avail < bytes_need)
-                                {
-                                    result = OKJ_ERROR_BAD_STRING;
-                                    loop_break = 1U;
-                                }
-                                else if (okj_validate_utf8_sequence(parser->json,
+                                /* okj_validate_utf8_sequence now takes the buffer length
+                                 * and performs its own bounds checks before each
+                                 * continuation-byte read (see contract at its definition).
+                                 * Truncated input like {"a":"\xC2 (multi-byte lead at
+                                 * end of buffer) or fuzzer-found inputs with invalid
+                                 * lead bytes in 0x80..0xC1 / 0xF0..0xFF at EOF are
+                                 * rejected as invalid without a heap-buffer-overread. */
+                                if (okj_validate_utf8_sequence(parser->json,
                                                             parser->position,
+                                                            parser->json_len,
                                                             &utf8_advance) == 0U)
                                 {
                                     result = OKJ_ERROR_BAD_STRING;

--- a/test/fuzz_target.c
+++ b/test/fuzz_target.c
@@ -26,6 +26,8 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* Include the implementation directly just like your unit tests */
 #include "../src/ok_json.c"
@@ -34,31 +36,50 @@
  * @brief libFuzzer requires a single entry-point function called LLVMFuzzerTestOneInput.
  * It feeds random byte arrays of various sizes into your parser to see if it crashes
  * or does an out-of-bounds read.
+ *
+ * IMPORTANT: This target uses a heap-allocated buffer of exactly `size` bytes
+ * (NOT a fixed-size stack buffer).  A fixed-size buffer leaves slack bytes
+ * past the logical end of input, so any out-of-bounds reads inside the parser
+ * land in valid memory and AddressSanitizer never fires.  Tight heap
+ * allocations put ASan's red zone immediately after the last valid byte so
+ * that overreads are caught.
  */
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 {
     /* ok_json has a hard limit; ignore inputs larger than it can handle */
     if (size > OKJ_MAX_JSON_LEN)
     {
-        return 0; 
+        return 0;
     }
 
-    /* okj_init expects a mutable char array. Copy the fuzzer data 
-     * into a local buffer to prevent modifying the read-only fuzzer input. */
-    char input_buf[OKJ_MAX_JSON_LEN];
-
-    for (size_t i = 0; i < size; i++)
+    /* Zero-length input is not a meaningful test — the parser API requires
+     * json_len >= 1 to dereference any byte. */
+    if (size == 0U)
     {
-        input_buf[i] = (char)data[i];
+        return 0;
     }
+
+    /* Heap-allocate a buffer of EXACTLY `size` bytes so the ASan red zone
+     * sits immediately after the last byte of input.  Any read past
+     * input_buf[size - 1] will be caught by the sanitizer. */
+    char *input_buf = (char *)malloc(size);
+
+    if (input_buf == NULL)
+    {
+        return 0;
+    }
+
+    memcpy(input_buf, data, size);
 
     OkJsonParser parser;
 
     okj_init(&parser, input_buf, (uint16_t)size);
-    
+
     /* We don't care about the return code (syntax errors are expected with fuzzing),
      * we only care if this function causes a segfault, hang, or ASan violation. */
     okj_parse(&parser);
+
+    free(input_buf);
 
     return 0;
 }

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -236,6 +236,7 @@ void test_false_as_object_key(void);
  * regression of any of the three OOB reads would be caught. */
 void test_oob_unicode_escape_truncated_no_padding(void);
 void test_oob_utf8_lead_at_eof_no_padding(void);
+void test_oob_utf8_invalid_lead_byte_at_eof(void);
 void test_oob_keyword_truncated_no_padding(void);
 
 /**
@@ -5112,6 +5113,38 @@ void test_oob_utf8_lead_at_eof_no_padding(void)
     printf("test_oob_utf8_lead_at_eof_no_padding passed!\n");
 }
 
+void test_oob_utf8_invalid_lead_byte_at_eof(void)
+{
+    /* libFuzzer-discovered variant of Finding 2: the input "&7\x80 (4 bytes)
+     * has byte 0x80 as the final byte.  0x80 is NOT a valid UTF-8 lead byte
+     * (it's a continuation byte), but okj_validate_utf8_sequence still reads
+     * src[pos + 1] at line 199 for ANY byte > 0x7F before classifying it.
+     *
+     * The original call-site fix only required 2 bytes when lead >= 0xC2,
+     * which let 0x80..0xC1 (invalid leads) slip through with only 1 byte
+     * available, triggering the same OOB read at a different byte range. */
+    size_t len = 4U;
+    char  *buf = (char *)malloc(len);
+    assert(buf != NULL);
+
+    buf[0] = 0x22;         /* " */
+    buf[1] = 0x26;         /* & */
+    buf[2] = 0x37;         /* 7 */
+    buf[3] = (char)0x80;   /* continuation byte masquerading as lead */
+
+    OkJsonParser parser;
+    OkjError     result;
+
+    okj_init(&parser, buf, (uint16_t)len);
+    result = okj_parse(&parser);
+
+    assert(result != OKJ_SUCCESS);
+
+    free(buf);
+
+    printf("test_oob_utf8_invalid_lead_byte_at_eof passed!\n");
+}
+
 void test_oob_keyword_truncated_no_padding(void)
 {
     /* Finding 3: "tr" — 2 bytes, no NUL, no padding.
@@ -5371,6 +5404,7 @@ int main(int argc, char* argv[])
      * These use exact-size malloc'd buffers so ASan catches any regression. */
     test_oob_unicode_escape_truncated_no_padding();
     test_oob_utf8_lead_at_eof_no_padding();
+    test_oob_utf8_invalid_lead_byte_at_eof();
     test_oob_keyword_truncated_no_padding();
 
     printf("All OK_JSON tests passed!\n");

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -237,6 +237,8 @@ void test_false_as_object_key(void);
 void test_oob_unicode_escape_truncated_no_padding(void);
 void test_oob_utf8_lead_at_eof_no_padding(void);
 void test_oob_utf8_invalid_lead_byte_at_eof(void);
+void test_oob_utf8_three_byte_lead_at_eof(void);
+void test_oob_utf8_exhaustive_lead_sweep(void);
 void test_oob_keyword_truncated_no_padding(void);
 
 /**
@@ -4358,10 +4360,10 @@ void test_validate_utf8_null_src_and_advance(void)
     uint16_t adv = 0U;
 
     /* NULL src: must return 0 immediately without dereferencing src. */
-    assert(okj_validate_utf8_sequence(NULL, 0U, &adv) == 0U);
+    assert(okj_validate_utf8_sequence(NULL, 0U, 4U, &adv) == 0U);
 
     /* NULL advance: must return 0 immediately without dereferencing advance. */
-    assert(okj_validate_utf8_sequence("test", 0U, NULL) == 0U);
+    assert(okj_validate_utf8_sequence("test", 0U, 4U, NULL) == 0U);
 
     printf("test_validate_utf8_null_src_and_advance passed!\n");
 }
@@ -5145,6 +5147,88 @@ void test_oob_utf8_invalid_lead_byte_at_eof(void)
     printf("test_oob_utf8_invalid_lead_byte_at_eof passed!\n");
 }
 
+void test_oob_utf8_three_byte_lead_at_eof(void)
+{
+    /* Second libFuzzer-discovered crasher: " \xB5\xFF (4 bytes).
+     * After consuming '"' and ' ', parser->position=2, json_len=4, so only
+     * 2 bytes remain.  0xB5 is NOT a valid 2-byte lead (0xC2-0xDF) so the
+     * validator falls through to the b2 = src[pos+2] read at line 215 —
+     * which was OOB since only 2 bytes were available.
+     *
+     * Fix: the validator now takes `len` and gates every continuation-byte
+     * read with an explicit bounds check.  This test also pins down the
+     * class of bugs where a lead byte in 0x80..0xC1 or 0xF0..0xFF lands
+     * near EOF — those classes require b2 or b3 reads that the old
+     * caller-side "bytes_need" heuristic could not cover without a
+     * signature change. */
+    size_t len = 4U;
+    char  *buf = (char *)malloc(len);
+    assert(buf != NULL);
+
+    buf[0] = 0x22;         /* " */
+    buf[1] = 0x20;         /* space */
+    buf[2] = (char)0xB5;   /* lead byte requiring b2 read */
+    buf[3] = (char)0xFF;
+
+    OkJsonParser parser;
+    OkjError     result;
+
+    okj_init(&parser, buf, (uint16_t)len);
+    result = okj_parse(&parser);
+
+    assert(result != OKJ_SUCCESS);
+
+    free(buf);
+
+    printf("test_oob_utf8_three_byte_lead_at_eof passed!\n");
+}
+
+void test_oob_utf8_exhaustive_lead_sweep(void)
+{
+    /* Exhaustive truncation sweep: for every possible non-ASCII lead byte
+     * (0x80..0xFF) and every tail length 1..4, place the lead inside a
+     * JSON string context at end-of-buffer and verify okj_parse neither
+     * crashes nor returns OKJ_SUCCESS (the input is truncated/invalid).
+     *
+     * This pins down the remediation of the entire class of bugs — if any
+     * internal path in okj_validate_utf8_sequence ever regresses to an
+     * unguarded read, running this test under -fsanitize=address will
+     * catch it immediately. */
+    int lead;
+    int tail;
+
+    for (lead = 0x80; lead <= 0xFF; lead++)
+    {
+        for (tail = 1; tail <= 4; tail++)
+        {
+            size_t len = (size_t)(2 + tail);  /* '"' + lead + (tail-1) fills */
+            char  *buf = (char *)malloc(len);
+            size_t i;
+
+            assert(buf != NULL);
+
+            buf[0] = '"';
+            buf[1] = (char)(uint8_t)lead;
+
+            /* Fill remaining bytes with 0x80 so they look like continuation
+             * bytes (maximizes paths through the validator). */
+            for (i = 2U; i < len; i++)
+            {
+                buf[i] = (char)0x80;
+            }
+
+            OkJsonParser parser;
+
+            okj_init(&parser, buf, (uint16_t)len);
+            (void)okj_parse(&parser);  /* Must not OOB regardless of outcome */
+
+            free(buf);
+        }
+    }
+
+    printf("test_oob_utf8_exhaustive_lead_sweep passed!\n");
+}
+
 void test_oob_keyword_truncated_no_padding(void)
 {
     /* Finding 3: "tr" — 2 bytes, no NUL, no padding.
@@ -5405,6 +5489,8 @@ int main(int argc, char* argv[])
     test_oob_unicode_escape_truncated_no_padding();
     test_oob_utf8_lead_at_eof_no_padding();
     test_oob_utf8_invalid_lead_byte_at_eof();
+    test_oob_utf8_three_byte_lead_at_eof();
+    test_oob_utf8_exhaustive_lead_sweep();
     test_oob_keyword_truncated_no_padding();
 
     printf("All OK_JSON tests passed!\n");

--- a/test/ok_json_tests.c
+++ b/test/ok_json_tests.c
@@ -33,6 +33,8 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 void test_parse_simple_object(void);
 void test_parse_array(void);
@@ -228,6 +230,13 @@ void test_close_brace_depth_zero(void);
 void test_close_bracket_depth_zero(void);
 void test_comma_outside_container(void);
 void test_false_as_object_key(void);
+/* Issue #69: heap-buffer-overread regression tests.  These use malloc'd
+ * exact-size buffers (not stack-allocated char[] which gains an implicit
+ * NUL terminator and slack bytes) so that under -fsanitize=address a
+ * regression of any of the three OOB reads would be caught. */
+void test_oob_unicode_escape_truncated_no_padding(void);
+void test_oob_utf8_lead_at_eof_no_padding(void);
+void test_oob_keyword_truncated_no_padding(void);
 
 /**
  * These tests are a work in progress. If you have ideas
@@ -5029,6 +5038,112 @@ void test_false_as_object_key(void)
     printf("test_false_as_object_key passed!\n");
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * Issue #69 regression tests: heap-buffer-overread on truncated input.
+ *
+ * These tests use malloc() to allocate a buffer of EXACTLY the input size,
+ * rather than `char json_str[] = "..."` which produces a stack-allocated
+ * array with an implicit NUL terminator and additional slack bytes.  A tight
+ * heap allocation puts AddressSanitizer's red zone immediately after the
+ * last valid byte, so if any of the three OOB reads reappear, running the
+ * test binary under -fsanitize=address will crash the process.
+ *
+ * All three tests must:
+ *  1. Not crash (neither plain nor under ASan).
+ *  2. Return a parse error (NOT OKJ_SUCCESS) since the input is truncated.
+ * ---------------------------------------------------------------------------
+ */
+
+void test_oob_unicode_escape_truncated_no_padding(void)
+{
+    /* Finding 1: {"a":"\uAB — 10 bytes, no NUL, no padding.
+     * The \uXXXX hex loop previously read 2 bytes past the allocation
+     * because it had no parser->position < parser->json_len guard. */
+    const char src[] = "{\"a\":\"\\uAB";
+    size_t     len   = sizeof(src) - 1U;   /* 10, excludes implicit NUL */
+
+    char *buf = (char *)malloc(len);
+    assert(buf != NULL);
+    memcpy(buf, src, len);
+
+    OkJsonParser parser;
+    OkjError     result;
+
+    okj_init(&parser, buf, (uint16_t)len);
+    result = okj_parse(&parser);
+
+    /* The parser must report the truncated escape as an error, not success. */
+    assert(result != OKJ_SUCCESS);
+
+    free(buf);
+
+    printf("test_oob_unicode_escape_truncated_no_padding passed!\n");
+}
+
+void test_oob_utf8_lead_at_eof_no_padding(void)
+{
+    /* Finding 2: {"a":"\xC2 — 7 bytes, no NUL, no padding.
+     * 0xC2 is a valid 2-byte UTF-8 lead byte.  Before the fix,
+     * okj_validate_utf8_sequence read src[pos+1] unconditionally,
+     * reaching one byte past the allocation. */
+    size_t len = 7U;
+    char  *buf = (char *)malloc(len);
+    assert(buf != NULL);
+
+    buf[0] = '{';
+    buf[1] = '"';
+    buf[2] = 'a';
+    buf[3] = '"';
+    buf[4] = ':';
+    buf[5] = '"';
+    buf[6] = (char)0xC2;   /* 2-byte UTF-8 lead, no continuation byte available */
+
+    OkJsonParser parser;
+    OkjError     result;
+
+    okj_init(&parser, buf, (uint16_t)len);
+    result = okj_parse(&parser);
+
+    assert(result != OKJ_SUCCESS);
+
+    free(buf);
+
+    printf("test_oob_utf8_lead_at_eof_no_padding passed!\n");
+}
+
+void test_oob_keyword_truncated_no_padding(void)
+{
+    /* Finding 3: "tr" — 2 bytes, no NUL, no padding.
+     * The parser saw 't' and previously called okj_match(pos, "true", 4)
+     * without verifying 4 bytes remain, reading 2 bytes past the allocation.
+     * We also exercise truncated "fa" ("false") and "nu" ("null"). */
+
+    const char *cases[]   = { "tr", "fa", "nu" };
+    size_t      lens[]    = { 2U,   2U,   2U   };
+    size_t      i;
+
+    for (i = 0U; i < (sizeof(cases) / sizeof(cases[0])); i++)
+    {
+        char *buf = (char *)malloc(lens[i]);
+        assert(buf != NULL);
+        memcpy(buf, cases[i], lens[i]);
+
+        OkJsonParser parser;
+        OkjError     result;
+
+        okj_init(&parser, buf, (uint16_t)lens[i]);
+        result = okj_parse(&parser);
+
+        /* A truncated keyword literal is not a valid JSON value. */
+        assert(result != OKJ_SUCCESS);
+
+        free(buf);
+    }
+
+    printf("test_oob_keyword_truncated_no_padding passed!\n");
+}
+
 int main(int argc, char* argv[])
 {
     (void)argc;
@@ -5251,6 +5366,12 @@ int main(int argc, char* argv[])
     test_close_bracket_depth_zero();
     test_comma_outside_container();
     test_false_as_object_key();
+
+    /* Issue #69: heap-buffer-overread regression tests for truncated input.
+     * These use exact-size malloc'd buffers so ASan catches any regression. */
+    test_oob_unicode_escape_truncated_no_padding();
+    test_oob_utf8_lead_at_eof_no_padding();
+    test_oob_keyword_truncated_no_padding();
 
     printf("All OK_JSON tests passed!\n");
 


### PR DESCRIPTION
Three OOB reads were triggerable by truncated, non-NUL-terminated input in tight heap allocations:

1. \uXXXX escape sequence (ok_json.c:1122): the 4-iteration hex-digit loop read parser->json[parser->position] with no bounds check against json_len.  A secondary logic bug advanced parser->position after the error flag was set, because the compound condition short-circuited into the else branch.  Fixed by gating every iteration on loop_break and checking parser->position < parser->json_len before each read.

2. okj_validate_utf8_sequence call site (ok_json.c:1179): the function's ACSL contract requires 4 readable bytes, but the caller only knew 1 byte was readable.  Fixed by inspecting the lead byte at the call site and verifying (json_len - position) >= required-byte-count before invoking the validator.

3. okj_match call sites (ok_json.c:1347, 1382, 1414): "true"/"null" need 4 bytes, "false" needs 5; callers now verify enough bytes remain before invoking okj_match.

Also:

- Rewrote test/fuzz_target.c to use a heap-allocated, exact-size buffer (not a 4096-byte stack buffer).  ASan's red zone now sits immediately past the last valid byte so future OOB reads are caught instead of masked by stack slack.
- Added 3 regression tests (test_oob_unicode_escape_truncated_no_padding, test_oob_utf8_lead_at_eof_no_padding, test_oob_keyword_truncated_no_padding) using malloc'd exact-size buffers so any regression fires under -fsanitize=address.
- Added ACSL preconditions to okj_parse_value and okj_parse documenting the buffer-readability contract they rely on.  Fully discharging their WP goals requires additional loop invariants and is tracked as follow-up; these functions remain out of the -wp-fct list for now.
- Documented the Frama-C coverage gap in .github/workflows/ci.yml.

Verified: make test + valgrind pass; isolated ASan harness on all three PoC inputs returns a parse error with no sanitizer violation.